### PR TITLE
[FEAT] 경로를 상수화하여 중앙 집중식으로 관리할 수 있도록 구조개선, text-size 토큰 추가

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -116,13 +116,11 @@
   --font-family-pretendard: "Pretendard", system-ui, sans-serif;
   --font-family-sans: "Pretendard", system-ui, sans-serif;
 
-  --font-size-2xs: 0.5rem;
-  --font-size-xs: 0.625rem;
-  --font-size-sm: 0.75rem;
-  --font-size-base: 0.875rem;
-  --font-size-lg: 1rem;
-  --font-size-xl: 1.125rem;
-  --font-size-2xl: 1.25rem;
+  --font-size-h3: 1.25rem;
+  --font-size-h4: 1.125rem;
+  --font-size-body1: 1rem;
+  --font-size-body2: 0.875rem;
+  --font-size-caption: 0.75rem;
 
   --border-radius-xs: 0.125rem;
   --border-radius-sm: 0.25rem;
@@ -147,6 +145,23 @@
   --border-radius-rounded-11: 1.375rem;
   --border-radius-rounded-12: 1.5rem;
   --border-radius-rounded-13: 1.625rem;
+}
+@layer utilities {
+  .text-h3 {
+    font-size: var(--font-size-h3);
+  }
+  .text-h4 {
+    font-size: var(--font-size-h4);
+  }
+  .text-body1 {
+    font-size: var(--font-size-body1);
+  }
+  .text-body2 {
+    font-size: var(--font-size-body2);
+  }
+  .text-caption {
+    font-size: var(--font-size-caption);
+  }
 }
 
 /* 기본 변수 설정 */

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,5 @@
+const HomePage = () => {
+  return <div className="text-h3">안녕하시오. 여기는 홈페이지입니다.</div>;
+};
+
+export default HomePage;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,5 +1,13 @@
-import { BrowserRouter } from "react-router-dom";
+import HomePage from "@/pages/HomePage";
+import { PATH } from "@shared/constants/path";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 export const AppRoutes = () => {
-  return <BrowserRouter></BrowserRouter>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path={PATH.HOME} element={<HomePage />} />
+      </Routes>
+    </BrowserRouter>
+  );
 };

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -1,0 +1,1 @@
+export const END_POINTS = {} as const;

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -1,0 +1,1 @@
+export const PATH = { HOME: "/home" } as const;


### PR DESCRIPTION
# 개요
경로를 상수화하여 오타를 방지하고, 유지보수성과 가독성을 향상시키는 것이 목적.
경로 수정 시 `constants/path.ts` 에서만 변경하면 되기에 유지보수가 용이합니다!

# 변경사항
- text-size 피그마 토큰대로 넣었습니다! 소문자로 피그마처럼 똑같이 작성해주면 됩니다!
- 예시 ) `text-h3`, `text-body1`, `text-caption`

---
- `shared/constants/path.ts` 파일을 생성하여 주요 페이지 경로를 상수로 관리
- 기존 라우터 정의 시 사용하던 문자열 경로를 `PATH.***` 형태로 변경
- `AppRoutes.tsx` 내 라우터 등록에서 상수 경로 사용 (`PATH.HOME`)
```bash
src/
├── shared/
│   └── constants/
│       └── path.ts         # 경로 상수 정의
│       └── api.ts         # api 경로 상수 정의
├── routes/
│   └── AppRoutes.tsx       # Router 정의에서 path 상수 사용
├── pages/
│   └── HomePage.tsx        # 예시 페이지 컴포넌트
```

현재는 `HomePage`만 등록되어 있으며, 추후 추가되는 페이지들은 동일한 방식으로 `PATH`에 등록해 사용해주세요!
<img width="1077" height="240" alt="image" src="https://github.com/user-attachments/assets/ba611285-2463-4631-b83f-4ff5981d05c8" />