### PR TITLE
[FEAT][UHYU-31] 공통 모달 컴포넌트(기본, 로그인) 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3",
     "react-icons": "^5.5.0",
-    "tailwind-merge": "^3.3.1"
+    "react-router-dom": "^7.6.3",
+    "tailwind-merge": "^3.3.1",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
 import { AppRoutes } from "@/routes/AppRoutes";
 
 function App() {
-  return <AppRoutes />;
+  return (
+    <>
+      <AppRoutes />
+    </>
+  );
 }
 
 export default App;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,5 +1,6 @@
-import BottomNavigation from "@shared/components/bottom_navigation/BottomNavigation";
 import HomePage from "@/pages/HomePage";
+import BottomNavigation from "@shared/components/bottom_navigation/BottomNavigation";
+import ModalRoot from "@shared/components/modal/ModalRoot";
 import { PATH } from "@shared/constants/path";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
@@ -10,6 +11,7 @@ export const AppRoutes = () => {
         <Route path={PATH.HOME} element={<HomePage />} />
       </Routes>
       <BottomNavigation />
+      <ModalRoot />
     </BrowserRouter>
   );
 };

--- a/src/shared/components/buttons/NavButton.tsx
+++ b/src/shared/components/buttons/NavButton.tsx
@@ -1,6 +1,14 @@
-import type { ButtonBaseProps } from "@shared/components/buttons/ButtonBase";
-import { ButtonBase } from "@shared/components/buttons/ButtonBase";
+import { ButtonBase, type ButtonBaseProps } from "./ButtonBase";
+import { Link, type LinkProps } from "react-router-dom";
 
-export const NavButton = ({ type = "button", ...props }: ButtonBaseProps) => {
-  return <ButtonBase variant="nav" type={type} {...props} />;
+type NavButtonProps = LinkProps & ButtonBaseProps;
+
+export const NavButton = ({ to, children, ...rest }: NavButtonProps) => {
+  return (
+    <Link to={to}>
+      <ButtonBase variant="nav" {...rest}>
+        {children}
+      </ButtonBase>
+    </Link>
+  );
 };

--- a/src/shared/components/modal/BaseModal.tsx
+++ b/src/shared/components/modal/BaseModal.tsx
@@ -1,0 +1,52 @@
+import { IconButton } from "@shared/components/buttons/IconButton";
+import { useModalStore } from "@shared/store/modalStore";
+import { X } from "lucide-react";
+import { useEffect } from "react";
+
+interface BaseModalProps {
+  title?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const BaseModal = ({ title, children }: BaseModalProps) => {
+  const closeModal = useModalStore((state) => state.closeModal);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) closeModal();
+  };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeModal();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? "modal-title" : undefined}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <section className="bg-white rounded-[16px] w-full px-[15px] pt-[10px] pb-[15px] min-w-[300px] max-w-lg mx-8 flex flex-col gap-[10px]">
+        <header className="flex justify-between items-center">
+          {title && (
+            <h3
+              id="modal-title"
+              className="break-word [overflow-wrap:anywhere] text-body1 font-bold"
+            >
+              {title}
+            </h3>
+          )}
+          <IconButton icon={<X className="h-4" onClick={closeModal} aria-label="모달 닫기" />} />
+        </header>
+        <main className="break-word flex flex-col">{children}</main>
+      </section>
+    </div>
+  );
+};
+
+export default BaseModal;

--- a/src/shared/components/modal/LoginModal.tsx
+++ b/src/shared/components/modal/LoginModal.tsx
@@ -1,0 +1,27 @@
+import { NavButton } from "@shared/components/buttons/NavButton";
+import { PATH } from "@shared/constants/path";
+import { useModalStore } from "@shared/store/modalStore";
+import BaseModal from "./BaseModal";
+
+const LoginModal = () => {
+  const closeModal = useModalStore((state) => state.closeModal);
+
+  const handleLogin = () => {
+    closeModal();
+  };
+
+  return (
+    <BaseModal title="로그인이 필요합니다">
+      <div className="flex flex-col gap-[12px]">
+        <p>
+          로그인을 해주시면 <br /> 더 많은 기능을 이용할 수 있습니다!
+        </p>
+        <NavButton to={PATH.LOGIN} onClick={handleLogin} className="w-full">
+          로그인 하러가기
+        </NavButton>
+      </div>
+    </BaseModal>
+  );
+};
+
+export default LoginModal;

--- a/src/shared/components/modal/ModalRoot.tsx
+++ b/src/shared/components/modal/ModalRoot.tsx
@@ -1,0 +1,18 @@
+import { useModalStore } from "@shared/store/modalStore";
+import BaseModal from "./BaseModal";
+
+const ModalRoot = () => {
+  const modalType = useModalStore((state) => state.modalType);
+  const modalProps = useModalStore((state) => state.modalProps);
+
+  if (modalType === "none") return null;
+
+  switch (modalType) {
+    case "base":
+      return <BaseModal title={modalProps.title}>{modalProps.children}</BaseModal>;
+    default:
+      return null;
+  }
+};
+
+export default ModalRoot;

--- a/src/shared/components/modal/ModalRoot.tsx
+++ b/src/shared/components/modal/ModalRoot.tsx
@@ -1,5 +1,6 @@
 import { useModalStore } from "@shared/store/modalStore";
 import BaseModal from "./BaseModal";
+import LoginModal from "./LoginModal";
 
 const ModalRoot = () => {
   const modalType = useModalStore((state) => state.modalType);
@@ -10,6 +11,8 @@ const ModalRoot = () => {
   switch (modalType) {
     case "base":
       return <BaseModal title={modalProps.title}>{modalProps.children}</BaseModal>;
+    case "login":
+      return <LoginModal />;
     default:
       return null;
   }

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -1,1 +1,7 @@
-export const PATH = { HOME: "/", MAP: "/map", BENEFIT: "/benefit", MYPAGE: "mypage" } as const;
+export const PATH = {
+  HOME: "/",
+  MAP: "/map",
+  BENEFIT: "/benefit",
+  MYPAGE: "/mypage",
+  LOGIN: "/login",
+} as const;

--- a/src/shared/store/modalStore.ts
+++ b/src/shared/store/modalStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+type ModalType = "base" | "none";
+
+interface ModalStore {
+  modalType: ModalType;
+  modalProps: {
+    title?: React.ReactNode;
+    children?: React.ReactNode;
+  };
+  openModal: (
+    type: ModalType,
+    props?: {
+      title?: React.ReactNode;
+      children?: React.ReactNode;
+    }
+  ) => void;
+  closeModal: () => void;
+}
+
+export const useModalStore = create<ModalStore>((set) => ({
+  modalType: "none",
+  modalProps: {},
+  openModal: (type, props = {}) => set({ modalType: type, modalProps: props }),
+  closeModal: () => set({ modalType: "none", modalProps: {} }),
+}));

--- a/src/shared/store/modalStore.ts
+++ b/src/shared/store/modalStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-type ModalType = "base" | "none";
+type ModalType = "none" | "base" | "login";
 
 interface ModalStore {
   modalType: ModalType;


### PR DESCRIPTION
# 개요
1️⃣ BaseModal : 기본 모달 UI 틀만 제공. 내용은 각자 페이지에서 자유롭게 children으로 구성합니다.
2️⃣ LoginModal : 로그인 요구 시 사용하는 전용 로그인 모달입니다. 별도 컴포넌트로 관리되며, modalType: `login`으로 호출합니다.

|기본 모달 열기|로그인 모달 열기|
|:--:|:--:|
|![baseModal](https://github.com/user-attachments/assets/ac9f02ce-fe95-450e-8f89-26b304c1c5d5)|![LoginModal](https://github.com/user-attachments/assets/fc237162-6046-41e3-8c46-744b97993f16)|

# 사용방법
## 1️⃣ BaseModal 사용 방법
각자 페이지에서 모달이 필요한 경우 아래 코드를 넣어줍니다.
```ts
const openModal = useModalStore((state) => state.openModal);
openModal("base", {
  title: "모달 제목",
  children: <모달에_보여줄_내용 />,
});
```
`title` : 모달 상단 제목 (생략해도 됩니다)
`children` : 모달 내부에 보여줄 JSX(HTML) 내용

## 2️⃣ LoginModal 사용 방법
```ts
const openModal = useModalStore((state) => state.openModal);
openModal("login");
// 로그인이 필요한 상황에서 이렇게 호출하면 됩니다.
```

```tsx
//사용예시
import { useModalStore } from "@shared/store/modalStore";

const HomePage = () => {
  const openModal = useModalStore((state) => state.openModal);
  const handleOpenLoginModal = () => {
    openModal("login");
  };

  return (
    <div className="flex flex-col gap-8">
      <button
        onClick={handleOpenLoginModal}
      >
        로그인 모달 열기
      </button>
    </div>
  );
};

export default HomePage;
```

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
