### PR TITLE
[FEAT][UHYU-31] common modal 

### DIFF
--- a/src/features/extra-info/components/StepContent.tsx
+++ b/src/features/extra-info/components/StepContent.tsx
@@ -1,6 +1,6 @@
 import { SelectionBottomSheet } from '@components/bottom_sheet/SelectionBottomSheet';
 import { BrandGrid } from '@components/brand_grid/BrandGrid';
-import { NavButton } from '@components/buttons/NavButton';
+import { ButtonBase } from '@components/buttons/ButtonBase';
 import { Input } from '@components/shadcn/ui/input';
 import { Label } from '@components/shadcn/ui/label';
 import React, { useState } from 'react';
@@ -66,7 +66,7 @@ export const StepContent: React.FC<StepContentProps> = ({
                 placeholder="이메일 주소를 입력해주세요"
                 disabled={disabled}
               />
-              <NavButton
+              <ButtonBase
                 disabled={
                   disabled || !data.email || !EMAIL_REGEX.test(data.email)
                 }
@@ -82,7 +82,7 @@ export const StepContent: React.FC<StepContentProps> = ({
                 }`}
               >
                 {data.emailVerified ? '✓ 확인완료' : '중복확인'}
-              </NavButton>
+              </ButtonBase>
             </div>
             <div className="min-h-[20px] mt-1 text-xs text-red-500 transition-all">
               {data.email !== '' &&

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,4 +1,5 @@
 import BottomNavigation from '@components/bottom_navigation/BottomNavigation';
+import ModalRoot from '@components/modals/ModalRoot';
 import HomePage from '@pages/HomePage';
 import BenefitPage from '@pages/benefit/BenefitPage';
 import ExtraInfo from '@pages/user/extra-info/ExtraInfo';
@@ -13,6 +14,7 @@ export const AppRoutes = () => {
         <Route path={PATH.EXTRA_INFO} element={<ExtraInfo />} />
       </Routes>
       <BottomNavigation />
+      <ModalRoot />
     </BrowserRouter>
   );
 };

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -4,4 +4,5 @@ export const PATH = {
   BENEFIT: '/benefit',
   MYPAGE: 'mypage',
   EXTRA_INFO: '/user/extra-info',
+  LOGIN: '/login',
 } as const;

--- a/src/shared/components/buttons/NavButton.tsx
+++ b/src/shared/components/buttons/NavButton.tsx
@@ -1,6 +1,14 @@
-import type { ButtonBaseProps } from '@components/buttons/ButtonBase';
-import { ButtonBase } from '@components/buttons/ButtonBase';
+import { Link, type LinkProps } from 'react-router-dom';
+import { ButtonBase, type ButtonBaseProps } from './ButtonBase';
 
-export const NavButton = ({ type = 'button', ...props }: ButtonBaseProps) => {
-  return <ButtonBase variant="nav" type={type} {...props} />;
+type NavButtonProps = LinkProps & ButtonBaseProps;
+
+export const NavButton = ({ to, children, ...rest }: NavButtonProps) => {
+  return (
+    <Link to={to}>
+      <ButtonBase variant="nav" {...rest}>
+        {children}
+      </ButtonBase>
+    </Link>
+  );
 };

--- a/src/shared/components/buttons/__stories__/NavButton.stories.tsx
+++ b/src/shared/components/buttons/__stories__/NavButton.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BrowserRouter } from 'react-router-dom';
 import { NavButton } from '../NavButton';
 
 const meta: Meta<typeof NavButton> = {
   title: 'Buttons/NavButton',
   component: NavButton,
   tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
   argTypes: {
     size: {
       control: 'select',
@@ -17,6 +25,7 @@ const meta: Meta<typeof NavButton> = {
 };
 
 export default meta;
+
 type Story = StoryObj<typeof NavButton>;
 
 export const Default: Story = {
@@ -27,7 +36,7 @@ export const Default: Story = {
   parameters: {
     docs: {
       source: {
-        code: `<NavButton size=\"md\">Nav Button</NavButton>`,
+        code: `<NavButton size="md">Nav Button</NavButton>`,
       },
     },
   },

--- a/src/shared/components/modals/BaseModal.tsx
+++ b/src/shared/components/modals/BaseModal.tsx
@@ -1,0 +1,56 @@
+import { IconButton } from '@components/buttons/IconButton';
+import { useModalStore } from '@shared/store/modalStore';
+import { X } from 'lucide-react';
+import { useEffect } from 'react';
+
+interface BaseModalProps {
+  title?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const BaseModal = ({ title, children }: BaseModalProps) => {
+  const closeModal = useModalStore(state => state.closeModal);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) closeModal();
+  };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? 'modal-title' : undefined}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <section className="bg-white rounded-[16px] w-full px-[15px] pt-[10px] pb-[15px] min-w-[300px] max-w-lg mx-8 flex flex-col gap-[10px]">
+        <header className="flex justify-between items-center">
+          {title && (
+            <h3
+              id="modal-title"
+              className="break-word [overflow-wrap:anywhere] text-body1 font-bold"
+            >
+              {title}
+            </h3>
+          )}
+          <IconButton
+            icon={
+              <X className="h-4" onClick={closeModal} aria-label="모달 닫기" />
+            }
+          />
+        </header>
+        <main className="break-word flex flex-col">{children}</main>
+      </section>
+    </div>
+  );
+};
+
+export default BaseModal;

--- a/src/shared/components/modals/LoginModal.tsx
+++ b/src/shared/components/modals/LoginModal.tsx
@@ -1,0 +1,27 @@
+import { NavButton } from '@components/buttons/NavButton';
+import { PATH } from '@paths';
+import { useModalStore } from '@shared/store/modalStore';
+import BaseModal from './BaseModal';
+
+const LoginModal = () => {
+  const closeModal = useModalStore(state => state.closeModal);
+
+  const handleLogin = () => {
+    closeModal();
+  };
+
+  return (
+    <BaseModal title="로그인이 필요합니다">
+      <div className="flex flex-col gap-[12px]">
+        <p>
+          로그인을 해주시면 <br /> 더 많은 기능을 이용할 수 있습니다!
+        </p>
+        <NavButton to={PATH.LOGIN} onClick={handleLogin} className="w-full">
+          로그인 하러가기
+        </NavButton>
+      </div>
+    </BaseModal>
+  );
+};
+
+export default LoginModal;

--- a/src/shared/components/modals/ModalRoot.tsx
+++ b/src/shared/components/modals/ModalRoot.tsx
@@ -1,0 +1,23 @@
+import { useModalStore } from '@shared/store/modalStore';
+import BaseModal from './BaseModal';
+import LoginModal from './LoginModal';
+
+const ModalRoot = () => {
+  const modalType = useModalStore(state => state.modalType);
+  const modalProps = useModalStore(state => state.modalProps);
+
+  if (modalType === 'none') return null;
+
+  switch (modalType) {
+    case 'base':
+      return (
+        <BaseModal title={modalProps.title}>{modalProps.children}</BaseModal>
+      );
+    case 'login':
+      return <LoginModal />;
+    default:
+      return null;
+  }
+};
+
+export default ModalRoot;

--- a/src/shared/components/modals/__stories__/BaseModal.stories.tsx
+++ b/src/shared/components/modals/__stories__/BaseModal.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import BaseModal from '../BaseModal';
+
+const meta: Meta<typeof BaseModal> = {
+  title: 'Components/Modal/BaseModal',
+  component: BaseModal,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BaseModal>;
+
+const BaseModalWrapper = () => {
+  const [visible, setVisible] = useState(true);
+
+  if (!visible)
+    return <button onClick={() => setVisible(true)}>모달 열기</button>;
+
+  return (
+    <BaseModal title="BaseModal 예시 타이틀">
+      <p>이 영역은 children으로 전달된 내용입니다.</p>
+    </BaseModal>
+  );
+};
+
+export const Default: Story = {
+  render: () => <BaseModalWrapper />,
+};

--- a/src/shared/components/modals/__stories__/LoginModal.stories.tsx
+++ b/src/shared/components/modals/__stories__/LoginModal.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import LoginModal from '../LoginModal';
+
+const meta: Meta<typeof LoginModal> = {
+  title: 'Components/Modal/LoginModal',
+  component: LoginModal,
+  decorators: [
+    Story => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LoginModal>;
+
+const LoginModalWrapper = () => {
+  const [visible, setVisible] = useState(true);
+
+  if (!visible)
+    return (
+      <button
+        onClick={() => setVisible(true)}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        로그인 모달 열기
+      </button>
+    );
+
+  return <LoginModal />;
+};
+
+export const Default: Story = {
+  render: () => <LoginModalWrapper />,
+};

--- a/src/shared/store/modalStore.ts
+++ b/src/shared/store/modalStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+type ModalType = 'none' | 'base' | 'login';
+
+interface ModalStore {
+  modalType: ModalType;
+  modalProps: {
+    title?: React.ReactNode;
+    children?: React.ReactNode;
+  };
+  openModal: (
+    type: ModalType,
+    props?: {
+      title?: React.ReactNode;
+      children?: React.ReactNode;
+    }
+  ) => void;
+  closeModal: () => void;
+}
+
+export const useModalStore = create<ModalStore>(set => ({
+  modalType: 'none',
+  modalProps: {},
+  openModal: (type, props = {}) => set({ modalType: type, modalProps: props }),
+  closeModal: () => set({ modalType: 'none', modalProps: {} }),
+}));


### PR DESCRIPTION
# 개요
1️⃣ BaseModal : 기본 모달 UI 틀만 제공. 내용은 각자 페이지에서 자유롭게 children으로 구성합니다.
2️⃣ LoginModal : 로그인 요구 시 사용하는 전용 로그인 모달입니다. 별도 컴포넌트로 관리되며, modalType: `login`으로 호출합니다.
3️⃣ NavButton 사용시 `to={PATH.~~}` 넣게 수정하였습니다!
`<NavButton to={PATH.LOGIN}>로그인 하러가기</NavButton>` 이렇게 사용해주셔야합니다 !

|기본 모달 열기|로그인 모달 열기|
|:--:|:--:|
|![baseModal](https://github.com/user-attachments/assets/ac9f02ce-fe95-450e-8f89-26b304c1c5d5)|![LoginModal](https://github.com/user-attachments/assets/fc237162-6046-41e3-8c46-744b97993f16)|

# 사용방법
## 1️⃣ BaseModal 사용 방법
각자 페이지에서 모달이 필요한 경우 아래 코드를 넣어줍니다.
```ts
const openModal = useModalStore((state) => state.openModal);
openModal("base", {
  title: "모달 제목",
  children: <모달에_보여줄_내용 />,
});
```
`title` : 모달 상단 제목 (생략해도 됩니다)
`children` : 모달 내부에 보여줄 JSX(HTML) 내용

## 2️⃣ LoginModal 사용 방법
```ts
const openModal = useModalStore((state) => state.openModal);
openModal("login");
// 로그인이 필요한 상황에서 이렇게 호출하면 됩니다.
```

```tsx
//사용예시
import { useModalStore } from "@shared/store/modalStore";

const HomePage = () => {
  const openModal = useModalStore((state) => state.openModal);
  const handleOpenLoginModal = () => {
    openModal("login");
  };

  return (
    <div className="flex flex-col gap-8">
      <button
        onClick={handleOpenLoginModal}
      >
        로그인 모달 열기
      </button>
    </div>
  );
};

export default HomePage;
```

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
