### PR TITLE
[FEAT][UHYU-156] base layout 설정

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,24 @@
 
 @custom-variant dark (&:is(.dark *));
 
+#root {
+  display: flex;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100vw;
+  height: 100vh;
+}
+
+/* src/index.css */
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollbar-hidden {
+  -ms-overflow-style: none; /* IE, Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
 /* Pretendard 폰트 로드 - 로컬 파일 사용 */
 @font-face {
   font-family: 'Pretendard';

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,19 +1,55 @@
+import BaseLayout from '@components/BaseLayout';
 import BottomNavigation from '@components/bottom_navigation/BottomNavigation';
 import ModalRoot from '@components/modals/ModalRoot';
 import HomePage from '@pages/HomePage';
 import BenefitPage from '@pages/benefit/BenefitPage';
 import ExtraInfo from '@pages/user/extra-info/ExtraInfo';
 import { PATH } from '@paths';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import {
+  BrowserRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom';
+
+const Layout = () => {
+  const { pathname } = useLocation();
+  const visibleBottomNavRoutes = [
+    PATH.HOME,
+    PATH.BENEFIT,
+    PATH.MAP,
+    PATH.MYPAGE,
+  ] as const;
+
+  const showBottomNav = visibleBottomNavRoutes.includes(
+    pathname as (typeof visibleBottomNavRoutes)[number]
+  );
+
+  return (
+    <div className="w-full h-full flex flex-col">
+      <BaseLayout>
+        <Outlet />
+      </BaseLayout>
+      {showBottomNav && <BottomNavigation />}
+    </div>
+  );
+};
+
 export const AppRoutes = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path={PATH.HOME} element={<HomePage />} />
-        <Route path={PATH.BENEFIT} element={<BenefitPage />} />
-        <Route path={PATH.EXTRA_INFO} element={<ExtraInfo />} />
+        <Route element={<Layout />}>
+          <Route path={PATH.HOME} element={<HomePage />} />
+          <Route path={PATH.MAP} element={<div>mapPage</div>} />
+          <Route path={PATH.BENEFIT} element={<BenefitPage />} />
+          <Route path={PATH.MYPAGE} element={<div>myPage</div>} />
+          <Route path={PATH.EXTRA_INFO} element={<ExtraInfo />} />
+          <Route path={PATH.LOGIN} element={<div>loginPage</div>} />
+        </Route>
       </Routes>
-      <BottomNavigation />
+
       <ModalRoot />
     </BrowserRouter>
   );

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -2,7 +2,7 @@ export const PATH = {
   HOME: '/',
   MAP: '/map',
   BENEFIT: '/benefit',
-  MYPAGE: 'mypage',
+  MYPAGE: '/mypage',
   EXTRA_INFO: '/user/extra-info',
   LOGIN: '/login',
 } as const;

--- a/src/shared/components/BaseLayout.tsx
+++ b/src/shared/components/BaseLayout.tsx
@@ -1,0 +1,13 @@
+interface BaseLayoutProps {
+  children: React.ReactNode;
+}
+
+const BaseLayout = ({ children }: BaseLayoutProps) => {
+  return (
+    <div className="flex-1 bg-white scrollbar-hidden overflow-hidden px-4 pt-[60px] pb-[40px] w-full max-w-[360px] mx-auto h-full overflow-y-auto">
+      {children}
+    </div>
+  );
+};
+
+export default BaseLayout;


### PR DESCRIPTION
# 개요
1️⃣ 기본 페이지들 패딩값 공통 적용
2️⃣ AppRouter 에서 바텀 네비 있는 페이지와 바텀 네비 없는 페이지 구분

|기본 페이지들 패딩값 공통 적용|바텀 네비 없는 페이지 구분|
|:--:|:--:|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/3d8743f7-a76a-4ef7-956e-b60d753bcafe" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/dc37dfb2-6cec-4757-a175-fae9e9f4a30c" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
