### PR TITLE
[FEAT][UHYU-168] my map 모달 구현(매장 삭제모달, mymap 삭제모달, mymap 공유모달 )

### DIFF
--- a/src/features/mymap/components/MymapDeleteModal.tsx
+++ b/src/features/mymap/components/MymapDeleteModal.tsx
@@ -1,0 +1,19 @@
+import BaseModal from "@components/modals/BaseModal";
+import { PrimaryButton } from "@extra-info/components/PrimaryButton";
+
+interface MymapDeleteModalProps {
+  onConfirm: () => void;
+}
+
+export const MymapDeleteModal = ({ onConfirm }: MymapDeleteModalProps) => {
+  return (
+    <BaseModal title="My Map 삭제">
+      <p className="text-sm text-black">
+        해당 My Map에 저장된 제휴처도 함께 사라져요
+      </p>
+      <div className="mt-4 flex justify-end gap-2">
+        <PrimaryButton onClick={onConfirm}>삭제</PrimaryButton>
+      </div>
+    </BaseModal>
+  );
+};

--- a/src/features/mymap/components/ShareModal.tsx
+++ b/src/features/mymap/components/ShareModal.tsx
@@ -1,0 +1,11 @@
+import BaseModal from '@components/modals/BaseModal';
+
+export const ShareModal = () => {
+  return (
+    <BaseModal title="My Map 공유">
+      <p className="text-sm text-black">
+        클립보드로 복사되었습니다.
+      </p>
+    </BaseModal>
+  );
+};

--- a/src/features/mymap/components/StoreDeleteModal.tsx
+++ b/src/features/mymap/components/StoreDeleteModal.tsx
@@ -1,0 +1,17 @@
+import BaseModal from "@components/modals/BaseModal";
+import { PrimaryButton } from "@extra-info/components/PrimaryButton";
+
+interface StoreDeleteModalProps {
+  onConfirm: () => void;
+}
+
+export const StoreDeleteModal = ({ onConfirm }: StoreDeleteModalProps) => {
+  return (
+    <BaseModal title="매장 삭제">
+      <p className="text-sm text-black">이 매장을 리스트에서 삭제합니다</p>
+      <div className="mt-4 flex justify-end gap-2">
+        <PrimaryButton onClick={onConfirm}>삭제</PrimaryButton>
+      </div>
+    </BaseModal>
+  );
+};


### PR DESCRIPTION
# 개요
mymap에 사용될 모달을 구현하였습니다.

<h3>✅ 사용법 </h3>
<pre><code class="language-tsx">const openModal = useModalStore(state =&gt; state.openModal);
const closeModal = useModalStore(state =&gt; state.closeModal);

openModal('base', {
  title: '모달 제목',
  children: &lt;모달에_보여줄_내용 /&gt;,
});
</code></pre>
<h3>📌 props 설명</h3>

Key | Type | Description
-- | -- | --
title | string or ReactNode | 모달 상단 제목
children | ReactNode | 모달 내부에 보여줄 JSX 콘텐츠


<hr>
<h2> 예시</h2>
<h3>1. mymap 삭제 모달 (<code inline="">MymapDeleteModal</code>)</h3>
<pre><code class="language-tsx">openModal('base', {
  title: '일반 삭제',
  children: &lt;MymapDeleteModal onConfirm={handleDelete} /&gt;,
});
</code></pre>
<h3>2. 공유 모달 (<code inline="">ShareModal</code>)</h3>
<pre><code class="language-tsx">openModal('base', {
  title: '공유',
  children: &lt;ShareModal /&gt;,
});
</code></pre>
<h3>3. 매장 삭제 모달 (<code inline="">StoreDeleteModal</code>)</h3>
<pre><code class="language-tsx">openModal('base', {
  title: '매장 삭제',
  children: &lt;StoreDeleteModal onConfirm={handleDelete} /&gt;,
});
</code></pre>
<hr>
<h2>모달 닫기</h2>
<p>모달 내부 혹은 외부 버튼에서 <code inline="">useModalStore</code>의 <code inline="">closeModal()</code>을 호출하면 닫힙니다.</p>
<pre><code class="language-tsx">const closeModal = useModalStore(state =&gt; state.closeModal);
closeModal();
</code></pre>

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
