### PR TITLE
[FEAT][UHYU-12] 지도 기본 기능 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",
     "react-icons": "^5.5.0",
+    "react-kakao-maps-sdk": "^1.2.0",
     "react-resizable-panels": "^3.0.3",
     "react-router-dom": "^7.6.3",
     "recharts": "^3.1.0",

--- a/src/features/kakao-map/KakaoMap.tsx
+++ b/src/features/kakao-map/KakaoMap.tsx
@@ -1,0 +1,23 @@
+import { Map } from 'react-kakao-maps-sdk';
+import useKakaoLoader from './hooks/useKakaoLoader';
+
+function KakaoMap() {
+  useKakaoLoader();
+
+  return (
+    <Map
+      id="map"
+      center={{
+        lat: 33.450701,
+        lng: 126.570667,
+      }}
+      style={{
+        width: '100%',
+        height: '350px',
+      }}
+      level={3}
+    />
+  );
+}
+
+export default KakaoMap;

--- a/src/features/kakao-map/api/endpoints.ts
+++ b/src/features/kakao-map/api/endpoints.ts
@@ -1,0 +1,10 @@
+export const MAP_ENDPOINTS = {
+  /** 주변 매장 목록 조회 */
+  GET_NEARBY_STORES: '/map/stores',
+  /** 매장 상세 정보 조회 */
+  GET_STORE_DETAIL: '/map/stores',
+  /** 매장 즐겨찾기 토글 */
+  TOGGLE_FAVORITE: '/map/stores',
+} as const;
+
+export type MapEndpoint = (typeof MAP_ENDPOINTS)[keyof typeof MAP_ENDPOINTS];

--- a/src/features/kakao-map/api/mapApi.ts
+++ b/src/features/kakao-map/api/mapApi.ts
@@ -1,0 +1,72 @@
+import { client } from '@client/axiosClient';
+import { MAP_ENDPOINTS } from './endpoints';
+import type {
+  GetNearbyStoresParams,
+  GetStoreDetailParams,
+  ToggleFavoriteParams,
+  StoreDetailResponse,
+  StoreListResponse,
+  ToggleFavoriteResponseType,
+} from './types';
+
+/**
+ * 개선된 Map API 함수들
+ *
+ * 주요 개선사항:
+ * 1. Path parameter 올바른 처리
+ * 2. HTTP 메서드별 적절한 데이터 전달 방식
+ * 3. 타입 안전성 강화
+ * 4. 에러 처리 고려
+ */
+export const mapApi = {
+  /**
+   * 주변 매장 목록 조회
+   * GET /map/stores?lat=37.123&lng=127.456&radius=1000
+   */
+  getStoreList: async (
+    params: GetNearbyStoresParams
+  ): Promise<StoreListResponse> => {
+    const response = await client.get<StoreListResponse>(
+      MAP_ENDPOINTS.GET_NEARBY_STORES,
+      {
+        params, // query parameter로 전달
+      }
+    );
+    return response.data;
+  },
+
+  /**
+   * 매장 상세 정보 조회
+   * GET /map/stores/123
+   */
+  getStoreDetail: async ({
+    storeId,
+  }: GetStoreDetailParams): Promise<StoreDetailResponse> => {
+    // path parameter를 URL에 직접 포함
+    const url = `${MAP_ENDPOINTS.GET_STORE_DETAIL}/${storeId}`;
+    const response = await client.get<StoreDetailResponse>(url);
+    return response.data;
+  },
+
+  /**
+   * 매장 즐겨찾기 토글
+   * POST /map/stores/123/favorite
+   */
+  toggleFavorite: async ({
+    storeId,
+  }: ToggleFavoriteParams): Promise<ToggleFavoriteResponseType> => {
+    // RESTful한 엔드포인트 구성
+    const url = `${MAP_ENDPOINTS.TOGGLE_FAVORITE}/${storeId}/favorite`;
+    const response = await client.post<ToggleFavoriteResponseType>(url);
+    return response.data;
+  },
+};
+
+// 타입 가드 함수들 (런타임 안전성을 위한 추가 보안)
+export const isValidStoreId = (storeId: unknown): storeId is number => {
+  return typeof storeId === 'number' && storeId > 0;
+};
+
+export const isValidCoordinate = (coord: unknown): coord is number => {
+  return typeof coord === 'number' && !isNaN(coord) && isFinite(coord);
+};

--- a/src/features/kakao-map/api/types.ts
+++ b/src/features/kakao-map/api/types.ts
@@ -1,0 +1,75 @@
+/**
+ * 공통 API 응답 구조
+ */
+export interface BaseResponse<T> {
+  statusCode: number;
+  message: string;
+  data: T;
+}
+
+/**
+ * 매장 혜택 정보
+ */
+export interface StoreBenefit {
+  grade: string;
+  benefitText: string;
+}
+
+/**
+ * 매장 상세 정보
+ */
+export interface StoreDetail {
+  storeName: string;
+  isFavorite: boolean;
+  favoriteCount: number;
+  benefits: StoreBenefit;
+  usageLimit: string;
+  usageMethod: string;
+}
+
+/**
+ * 매장 목록 정보
+ */
+export interface StoreSummary {
+  storeId: number;
+  storeName: string;
+  categoryName: string;
+  addressDetail: string;
+  benefit: string;
+  logo_image: string;
+  brandName: string;
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * 즐겨찾기 토글 응답
+ */
+export interface ToggleFavoriteResponse {
+  storeId: number;
+  isBookmarked: boolean;
+}
+
+/**
+ * API 응답 타입들
+ */
+export type StoreDetailResponse = BaseResponse<StoreDetail>;
+export type StoreListResponse = BaseResponse<StoreSummary[]>;
+export type ToggleFavoriteResponseType = BaseResponse<ToggleFavoriteResponse>;
+
+/**
+ * API 요청 파라미터 타입들
+ */
+export interface GetNearbyStoresParams {
+  lat: number;
+  lng: number;
+  radius: number;
+}
+
+export interface GetStoreDetailParams {
+  storeId: number;
+}
+
+export interface ToggleFavoriteParams {
+  storeId: number;
+}

--- a/src/features/kakao-map/components/BrandMarker.tsx
+++ b/src/features/kakao-map/components/BrandMarker.tsx
@@ -1,0 +1,90 @@
+// components/AdvancedBrandMarker.tsx
+import { type FC } from 'react';
+import { getBrandImagePath } from '../utils/brandImageMapper.ts';
+import { getStoreCategory } from '../utils/categoryMapper.ts';
+import { CATEGORY_CONFIGS } from '../types/category.ts';
+import type { Store } from '../types/store.ts';
+
+interface BrandMarkerProps {
+  store: Store;
+  isSelected?: boolean;
+  hasPromotion?: boolean;
+  onClick?: () => void;
+}
+
+const BrandMarker: FC<BrandMarkerProps> = ({
+  store,
+  isSelected = false,
+  hasPromotion = false,
+  onClick,
+}) => {
+  // 매장 이름으로부터 카테고리를 추출
+  const category = getStoreCategory(store.storeName);
+  const categoryConfig = CATEGORY_CONFIGS[category];
+  const brandImageSrc = getBrandImagePath(store.brandName);
+
+  return (
+    <div className="relative" onClick={onClick}>
+      {/* 프로모션 배지 */}
+      {hasPromotion && (
+        <div className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 rounded-full flex items-center justify-center z-10">
+          <span className="text-white text-xs font-bold">!</span>
+        </div>
+      )}
+
+      {/* 메인 마커 */}
+      <div
+        className={`
+          relative 
+          w-14 h-14 
+          ${categoryConfig.color}
+          rounded-full 
+          shadow-lg 
+          border-3 
+          border-white
+          cursor-pointer
+          transition-all 
+          duration-200
+          hover:scale-110
+          ${isSelected ? `ring-4 ${categoryConfig.ringColor}` : ''}
+        `}
+      >
+        {/* 브랜드 로고 */}
+        <div className="absolute inset-2 bg-white rounded-full overflow-hidden">
+          <img
+            src={brandImageSrc}
+            alt={`${store.storeName} 마커`}
+            className="w-full h-full object-cover"
+          />
+        </div>
+
+        {/* 마커 포인터 */}
+        <div
+          className={`
+            absolute 
+            top-full 
+            left-1/2
+            transform
+            -translate-x-1/2
+            w-0 h-0
+            border-l-6
+            border-r-6
+            border-t-10
+            border-transparent
+            ${categoryConfig.color}
+            drop-shadow-md
+          `}
+        />
+      </div>
+
+      {/* 선택 상태 펄스 */}
+      {isSelected && (
+        <div
+          className={`absolute inset-0 rounded-full border-2 border-blue-400 animate-ping`}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BrandMarker;

--- a/src/features/kakao-map/components/LocationButton.tsx
+++ b/src/features/kakao-map/components/LocationButton.tsx
@@ -1,0 +1,93 @@
+import { type FC } from 'react';
+import { FaLocationArrow } from 'react-icons/fa';
+
+interface LocationButtonProps {
+  onClick: () => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+const LocationButton: FC<LocationButtonProps> = ({
+  onClick,
+  isLoading = false,
+  className = '',
+}) => {
+  return (
+    <div className="relative inline-block group">
+      <button
+        onClick={onClick}
+        disabled={isLoading}
+        className={`
+          w-12 h-12 
+          bg-white 
+          rounded-full 
+          shadow-lg 
+          flex items-center justify-center 
+          hover:bg-gray-50 
+          active:bg-gray-100 
+          disabled:opacity-50 
+          disabled:cursor-not-allowed
+          transition-all duration-200
+          ${className}
+        `}
+        aria-label="내 위치로 이동"
+      >
+        {isLoading ? (
+          <div className="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        ) : (
+          <FaLocationArrow className="w-5 h-5 text-blue-500" />
+        )}
+      </button>
+
+      {/* 툴팁 */}
+      <div
+        className="
+        absolute 
+        bottom-full 
+        left-1/2 
+        transform 
+        -translate-x-1/2 
+        mb-2 
+        px-3 
+        py-1.5 
+        bg-gray-900 
+        text-white 
+        text-xs 
+        font-medium
+        rounded-md 
+        shadow-lg
+        opacity-0 
+        group-hover:opacity-100 
+        transition-opacity 
+        duration-200 
+        pointer-events-none
+        whitespace-nowrap
+        z-50
+        invisible
+        group-hover:visible
+      "
+      >
+        내 위치로 이동
+        {/* 툴팁 화살표 */}
+        <div
+          className="
+          absolute 
+          top-full 
+          left-1/2 
+          transform 
+          -translate-x-1/2 
+          w-0 
+          h-0 
+          border-l-4 
+          border-r-4 
+          border-t-4 
+          border-transparent 
+          border-t-gray-900
+        "
+        />
+      </div>
+    </div>
+  );
+};
+
+export default LocationButton;

--- a/src/features/kakao-map/components/MapTopControls.tsx
+++ b/src/features/kakao-map/components/MapTopControls.tsx
@@ -1,0 +1,50 @@
+import { type FC } from 'react';
+import SearchInput from '@components/search_input/SearchInput';
+import FilterTabs from '@components/filter_tabs/FilterTabs';
+import RegionFilterDropdown from '@features/kakao-map/components/RegionFilterDropdown';
+
+interface MapTopControlsProps {
+  searchValue: string;
+  onSearchValueChange: (value: string) => void;
+  onSearch: (value: string) => void;
+  onSearchCancel: () => void;
+  activeFilter: string;
+  onFilterChange: (value: string) => void;
+}
+
+const MapTopControls: FC<MapTopControlsProps> = ({
+  searchValue,
+  onSearchValueChange,
+  onSearch,
+  onSearchCancel,
+  activeFilter,
+  onFilterChange,
+}) => {
+  return (
+    <div className="absolute top-4 left-4 right-4 z-10">
+      <SearchInput
+        value={searchValue}
+        onChange={onSearchValueChange}
+        onSearch={onSearch}
+        onCancel={onSearchCancel}
+        placeholder="장소 검색"
+        variant="white"
+      />
+      <div className="flex items-center justify-between mt-2 min-h-[44px] w-full">
+        {/* 왼쪽: 지역별 필터 */}
+        <div className="flex-shrink-0">
+          <RegionFilterDropdown
+            value={activeFilter}
+            onChange={onFilterChange}
+          />
+        </div>
+        {/* 가운데: 필터탭 */}
+        <div className="flex-1 flex justify-center">
+          <FilterTabs onChange={onFilterChange} variant="gray" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MapTopControls;

--- a/src/features/kakao-map/components/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/MapWithMarkers.tsx
@@ -1,0 +1,70 @@
+// MapWithMarkers.tsx
+import { Map, CustomOverlayMap } from 'react-kakao-maps-sdk';
+import { type FC, useState } from 'react';
+import type { Store } from '../types/store';
+import BrandMarker from './BrandMarker';
+
+interface MapWithMarkersProps {
+  center: { lat: number; lng: number };
+  stores: Store[];
+  currentLocation?: { lat: number; lng: number } | null;
+  level?: number;
+  className?: string;
+  onStoreClick?: (store: Store) => void;
+}
+
+const MapWithMarkers: FC<MapWithMarkersProps> = ({
+  center,
+  stores,
+  currentLocation,
+  level = 4,
+  className = 'w-full h-full',
+  onStoreClick,
+}) => {
+  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
+
+  const handleMarkerClick = (store: Store) => {
+    setSelectedStoreId(store.storeId);
+    onStoreClick?.(store);
+  };
+
+  return (
+    <Map id="map" center={center} className={className} level={level}>
+      {/* 매장 마커들 */}
+      {stores.map(store => (
+        <CustomOverlayMap
+          key={store.storeId}
+          position={{ lat: store.latitude, lng: store.longitude }}
+          yAnchor={1} // 마커의 아래쪽 포인트가 좌표에 위치하도록
+          xAnchor={0.5} // 마커의 중앙이 좌표에 위치하도록
+        >
+          <BrandMarker
+            store={store}
+            isSelected={selectedStoreId === store.storeId}
+            hasPromotion={store.benefit !== undefined} // 혜택이 있으면 프로모션 배지 표시
+            onClick={() => handleMarkerClick(store)}
+          />
+        </CustomOverlayMap>
+      ))}
+
+      {/* 사용자 위치 마커 */}
+      {currentLocation && (
+        <CustomOverlayMap
+          position={currentLocation}
+          yAnchor={0.5}
+          xAnchor={0.5}
+        >
+          <div className="relative">
+            {/* 사용자 위치 표시 */}
+            <div className="w-4 h-4 bg-blue-500 rounded-full border-2 border-white shadow-lg" />
+
+            {/* 위치 정확도 표시 원 */}
+            <div className="absolute inset-0 w-12 h-12 border-2 border-blue-300 rounded-full opacity-30 animate-pulse transform -translate-x-1/2 -translate-y-1/2 translate-x-2 translate-y-2" />
+          </div>
+        </CustomOverlayMap>
+      )}
+    </Map>
+  );
+};
+
+export default MapWithMarkers;

--- a/src/features/kakao-map/components/PersistentBottomSheet.tsx
+++ b/src/features/kakao-map/components/PersistentBottomSheet.tsx
@@ -1,0 +1,179 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FaFilter } from 'react-icons/fa';
+
+interface Step {
+  key: string;
+  title: string;
+  subtitle?: string;
+  content: React.ReactNode;
+  showBackButton?: boolean;
+  showFilterButton?: boolean;
+  onFilterClick?: () => void;
+}
+interface PersistentBottomSheetProps {
+  /** 바텀시트에 표시할 스텝들의 배열 */
+  steps: Step[];
+
+  /** 현재 표시되어야 하는 스텝의 키 (부모에서 완전히 제어) */
+  currentStepKey: string;
+
+  /** 스텝이 변경될 때 호출될 콜백 함수 */
+  onStepChange: (stepKey: string) => void;
+
+  /** 바텀시트의 최소 높이 (접힌 상태) */
+  minHeight?: number;
+
+  /** 바텀시트의 최대 높이 (펼쳐진 상태) */
+  maxHeight?: number;
+
+  /** 초기에 펼쳐진 상태로 시작할지 여부 */
+  defaultExpanded?: boolean;
+
+  /** 하단 네비게이션 바의 높이 (바텀시트 위치 계산용) */
+  bottomNavHeight?: number;
+
+  /** 외부에서 제어하는 확장 상태 */
+  isExpanded?: boolean;
+
+  /** 확장 상태 변경 콜백 */
+  onExpandedChange?: (expanded: boolean) => void;
+}
+
+export const PersistentBottomSheet: React.FC<PersistentBottomSheetProps> = ({
+  steps,
+  currentStepKey,
+  onStepChange,
+  minHeight = 80,
+  maxHeight = 400,
+  defaultExpanded = false,
+  bottomNavHeight = 60,
+  isExpanded: controlledIsExpanded,
+  onExpandedChange,
+}) => {
+  const [internalIsExpanded, setInternalIsExpanded] = useState(defaultExpanded);
+
+  // 외부에서 제어하는 경우 외부 상태를, 그렇지 않으면 내부 상태를 사용
+  const isExpanded =
+    controlledIsExpanded !== undefined
+      ? controlledIsExpanded
+      : internalIsExpanded;
+
+  const currentStep = steps.find(step => step.key === currentStepKey);
+
+  const goBackToFirstStep = () => {
+    const firstStep = steps[0];
+    if (firstStep) {
+      onStepChange(firstStep.key);
+    }
+  };
+
+  const toggleExpansion = () => {
+    if (onExpandedChange) {
+      onExpandedChange(!isExpanded);
+    } else {
+      setInternalIsExpanded(prev => !prev);
+    }
+  };
+
+  const bottomSheetStyle = {
+    bottom: `${bottomNavHeight}px`,
+  };
+
+  if (!currentStep) {
+    console.error(`스텝을 찾을 수 없습니다: ${currentStepKey}`);
+    return null;
+  }
+
+  return (
+    <motion.div
+      className="fixed left-0 right-0 bg-white rounded-t-2xl shadow-2xl z-40 border border-gray-200"
+      style={bottomSheetStyle}
+      initial={{ height: minHeight }}
+      animate={{
+        height: isExpanded ? maxHeight : minHeight,
+      }}
+      transition={{
+        type: 'spring',
+        damping: 25,
+        stiffness: 200,
+      }}
+    >
+      <div className="flex flex-col h-full">
+        <div
+          className="flex justify-center py-3 cursor-pointer flex-shrink-0 border-b border-gray-100 hover:bg-gray-50 transition-colors"
+          onClick={toggleExpansion}
+          role="button"
+          aria-label={isExpanded ? '바텀시트 접기' : '바텀시트 펼치기'}
+        >
+          <div className="w-12 h-1.5 bg-gray-300 rounded-full" />
+        </div>
+
+        {/* 헤더 영역 */}
+        <div className="flex-shrink-0 px-6 py-4 border-b border-gray-100">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <h2 className="text-lg font-bold text-gray-900">
+                {currentStep.title}
+              </h2>
+              {currentStep.subtitle && (
+                <p className="text-sm text-gray-500 mt-1">
+                  {currentStep.subtitle}
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              {/* 필터 버튼 */}
+              {currentStep.showFilterButton && currentStep.onFilterClick && (
+                <button
+                  className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 border border-gray-200 hover:border-blue-300 shadow-sm hover:shadow-md"
+                  onClick={currentStep.onFilterClick}
+                  aria-label="필터 설정"
+                >
+                  <FaFilter className="w-3.5 h-3.5" />
+                  <span>필터</span>
+                </button>
+              )}
+
+              {/* 뒤로 가기 버튼 */}
+              {currentStep.showBackButton &&
+                currentStepKey !== steps[0]?.key && (
+                  <button
+                    className="px-3 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md"
+                    onClick={goBackToFirstStep}
+                    aria-label="이전 화면으로 돌아가기"
+                  >
+                    뒤로
+                  </button>
+                )}
+            </div>
+          </div>
+        </div>
+
+        {/* 콘텐츠 영역 */}
+        {isExpanded && (
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={currentStepKey}
+                className="h-full"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.15 }}
+              >
+                {currentStep.content}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+        )}
+
+        {/* 접힌 상태에서의 미리보기 */}
+        {!isExpanded && (
+          <div className="flex-1 px-6 py-2 flex items-center"></div>
+        )}
+      </div>
+    </motion.div>
+  );
+};

--- a/src/features/kakao-map/components/RegionFilterDropdown.tsx
+++ b/src/features/kakao-map/components/RegionFilterDropdown.tsx
@@ -1,0 +1,55 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+  SelectGroup,
+  SelectLabel,
+} from '@shared/components/shadcn/ui/select';
+
+const regions = [
+  { label: '전체', value: 'all' },
+  { label: '서울', value: 'seoul' },
+  { label: '경기', value: 'gyeonggi' },
+  { label: '인천', value: 'incheon' },
+  { label: '부산', value: 'busan' },
+  { label: '제주', value: 'jeju' },
+  { label: '강원', value: 'gangwon' },
+  { label: '충청', value: 'chungcheong' },
+  { label: '전라', value: 'jeollanam' },
+  { label: '경상', value: 'gyeongsang' },
+  { label: '전북', value: 'jeonbuk' },
+  { label: '전남', value: 'jeonnam' },
+  { label: '경북', value: 'gyeongbuk' },
+];
+
+export default function RegionFilterDropdown({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-32 h-10 bg-white border border-gray-200 rounded-lg shadow text-sm font-medium">
+        <SelectValue placeholder="지역별" />
+      </SelectTrigger>
+      <SelectContent
+        position="popper"
+        sideOffset={4}
+        className="bg-white border border-gray-200 shadow-lg rounded-lg z-50"
+      >
+        <SelectGroup>
+          <SelectLabel>지역 선택</SelectLabel>
+          {regions.map(region => (
+            <SelectItem key={region.value} value={region.value}>
+              {region.label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/features/kakao-map/components/StoreListContent.tsx
+++ b/src/features/kakao-map/components/StoreListContent.tsx
@@ -1,0 +1,62 @@
+import { type FC } from 'react';
+import { BrandWithFavoriteCard } from '@components/cards/BrandWithFavoriteCard';
+import type { Store } from '@/features/kakao-map/types/store';
+import { getBrandImagePath } from '../utils/brandImageMapper';
+
+interface StoreListContentProps {
+  stores: Store[];
+  onFilterClick: () => void;
+  onStoreClick?: (store: Store) => void;
+}
+
+const StoreListContent: FC<StoreListContentProps> = ({
+  stores,
+  onStoreClick,
+}) => {
+  return (
+    <div className="flex flex-col h-full">
+      {/* 필터 헤더 - 고정 */}
+      <div className="flex-shrink-0 px-4 py-3 border-b border-gray-100">
+        <div className="flex justify-between items-center"></div>
+      </div>
+
+      {/* 스토어 리스트 - 스크롤 가능 */}
+      <div className="flex-1 overflow-y-auto">
+        {stores.length === 0 ? (
+          <div className="flex justify-center items-center py-8">
+            <div className="text-gray-400">주변에 매장이 없습니다</div>
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {stores.map(store => (
+              <div
+                key={store.storeId}
+                className="p-4 hover:bg-gray-50 transition-colors cursor-pointer"
+                onClick={() => onStoreClick?.(store)}
+              >
+                <BrandWithFavoriteCard
+                  logoUrl={getBrandImagePath(store.brandName)}
+                  isStarFilled={false}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="font-semibold text-gray-900 truncate">
+                      {store.storeName}
+                    </div>
+                    <div className="text-xs text-gray-500 mt-1 truncate">
+                      {store.addressDetail}
+                    </div>
+                    <div className="text-xs text-red-500 mt-1 font-medium">
+                      {store.benefit}
+                    </div>
+                  </div>
+                </BrandWithFavoriteCard>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StoreListContent;

--- a/src/features/kakao-map/components/steps/BrandSelectContent.tsx
+++ b/src/features/kakao-map/components/steps/BrandSelectContent.tsx
@@ -1,0 +1,179 @@
+import { type FC } from 'react';
+
+/**
+ * BrandSelectContent 컴포넌트의 Props 정의
+ */
+interface BrandSelectContentProps {
+  /** 현재 선택된 카테고리 키 (컨텍스트 표시용) */
+  categoryKey: string;
+
+  /** 카테고리 표시 이름 (사용자에게 보여줄 이름) */
+  categoryDisplayName: string;
+
+  /** 선택 가능한 브랜드 목록 (백엔드 API에서 조회된 실제 데이터) */
+  brands: string[];
+
+  /** 현재 선택된 브랜드 (선택 상태 표시용) */
+  selectedBrand?: string;
+
+  /** 브랜드 목록 로딩 상태 */
+  isLoading?: boolean;
+
+  onBrandSelect: (brandName: string) => void;
+  onBack: () => void;
+}
+
+const BrandSelectContent: FC<BrandSelectContentProps> = ({
+  categoryDisplayName,
+  brands,
+  selectedBrand,
+  isLoading = false,
+  onBrandSelect,
+  onBack,
+}) => {
+  /**
+   * 브랜드 선택 핸들러
+   *
+   * 사용자가 브랜드를 선택했을 때 호출되며,
+   * 부모 컴포넌트에 선택 결과를 전달합니다.
+   */
+  const handleBrandClick = (brandName: string) => {
+    console.log('🏢 브랜드 선택:', brandName);
+    onBrandSelect(brandName);
+  };
+
+  /**
+   * 로딩 상태 렌더링
+   *
+   */
+  const renderLoadingState = () => (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center">
+        <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+        <p className="text-gray-600">브랜드 목록을 불러오는 중...</p>
+      </div>
+    </div>
+  );
+
+  /**
+   * 빈 상태 렌더링
+   */
+  const renderEmptyState = () => (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center py-8">
+        <div className="text-4xl mb-4">🏪</div>
+        <p className="text-gray-600 mb-2">{categoryDisplayName} 카테고리에</p>
+        <p className="text-gray-600 mb-4">등록된 브랜드가 없습니다</p>
+        <p className="text-sm text-gray-500">다른 카테고리를 선택해 보세요</p>
+      </div>
+    </div>
+  );
+
+  /**
+   * 브랜드 목록 렌더링
+   *
+   * 실제 브랜드 목록을 표시하는 메인 콘텐츠입니다.
+   */
+  const renderBrandList = () => (
+    <div className="flex-1 overflow-y-auto">
+      <div className="p-6 space-y-3">
+        {brands.map(brand => {
+          const isSelected = selectedBrand === brand;
+
+          return (
+            <button
+              key={brand}
+              onClick={() => handleBrandClick(brand)}
+              className={`
+                w-full flex items-center justify-between
+                p-4 rounded-xl border-2 transition-all duration-200
+                focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+                ${
+                  isSelected
+                    ? 'border-blue-500 bg-blue-50 text-blue-700'
+                    : 'border-gray-200 hover:border-blue-300 hover:bg-blue-25 text-gray-700'
+                }
+              `}
+              aria-label={`${brand} 브랜드 선택`}
+            >
+              {/* 브랜드 이름 */}
+              <span className="font-medium text-left">{brand}</span>
+
+              {/* 선택 상태 표시 또는 화살표 */}
+              <div className="flex items-center">
+                {isSelected ? (
+                  <div className="w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center">
+                    <svg
+                      className="w-4 h-4 text-white"
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path d="M5 13l4 4L19 7"></path>
+                    </svg>
+                  </div>
+                ) : (
+                  <svg
+                    className="w-5 h-5 text-gray-400"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path d="M9 5l7 7-7 7"></path>
+                  </svg>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* 헤더 영역 - 뒤로가기 버튼과 카테고리 이름 */}
+      <div className="flex-shrink-0 px-6 py-4 border-b border-gray-100">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onBack}
+            className="flex items-center text-gray-600 hover:text-gray-800 transition-colors"
+            aria-label="이전 화면으로 돌아가기"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <span className="text-lg font-medium text-gray-900">
+            {categoryDisplayName}
+          </span>
+        </div>
+      </div>
+
+      {/* 메인 콘텐츠 영역 */}
+      {isLoading
+        ? renderLoadingState()
+        : brands.length === 0
+          ? renderEmptyState()
+          : renderBrandList()}
+    </div>
+  );
+};
+
+export default BrandSelectContent;

--- a/src/features/kakao-map/components/steps/CategorySelectContent.tsx
+++ b/src/features/kakao-map/components/steps/CategorySelectContent.tsx
@@ -1,0 +1,64 @@
+import { type FC } from 'react';
+
+interface CategorySelectContentProps {
+  selectedCategory: string;
+  onCategorySelect: (categoryKey: string) => void;
+}
+
+const CategorySelectContent: FC<CategorySelectContentProps> = ({
+  selectedCategory,
+  onCategorySelect,
+}) => {
+  const categories = [
+    { key: 'lifestyle', name: '생활/편의', icon: '🏪' },
+    { key: 'food', name: '푸드', icon: '🍽️' },
+    { key: 'beauty', name: '뷰티/건강', icon: '💄' },
+    { key: 'shopping', name: '쇼핑', icon: '🛍️' },
+    { key: 'culture', name: '문화/여가', icon: '🎬' },
+    { key: 'activity', name: '액티비티', icon: '🏃' },
+    { key: 'education', name: '교육', icon: '📚' },
+    { key: 'travel', name: '여행/교통', icon: '✈️' },
+  ];
+
+  const handleCategoryClick = (categoryKey: string) => {
+    onCategorySelect(categoryKey);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto">
+        <div className="p-4">
+          <div className="grid grid-cols-2 gap-3">
+            {categories.map(category => {
+              const isSelected = selectedCategory === category.key;
+
+              return (
+                <button
+                  key={category.key}
+                  onClick={() => handleCategoryClick(category.key)}
+                  className={`
+                    flex flex-col items-center justify-center
+                    p-4 rounded-xl border transition-colors duration-200
+                    h-20 focus:outline-none focus:ring-2 focus:ring-blue-500
+                    ${
+                      isSelected
+                        ? 'border-blue-500 bg-blue-50 text-blue-700'
+                        : 'border-gray-200 bg-white hover:bg-gray-50 text-gray-700'
+                    }
+                  `}
+                >
+                  <span className="text-lg mb-1">{category.icon}</span>
+                  <span className="text-xs font-medium text-center leading-tight">
+                    {category.name}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CategorySelectContent;

--- a/src/features/kakao-map/hooks/useKakaoLoader.tsx
+++ b/src/features/kakao-map/hooks/useKakaoLoader.tsx
@@ -1,0 +1,14 @@
+import { useKakaoLoader as useKakaoLoaderOrigin } from 'react-kakao-maps-sdk';
+
+export default function useKakaoLoader() {
+  useKakaoLoaderOrigin({
+    /**
+     * ※주의※ appkey의 경우 본인의 appkey를 사용하셔야 합니다.
+     * 해당 키는 docs를 위해 발급된 키 이므로, 임의로 사용하셔서는 안됩니다.
+     *
+     * @참고 https://apis.map.kakao.com/web/guide/
+     */
+    appkey: import.meta.env.VITE_KAKAO_JS_KEY!,
+    libraries: ['clusterer', 'drawing', 'services'],
+  });
+}

--- a/src/features/kakao-map/hooks/useMapQueryies.ts
+++ b/src/features/kakao-map/hooks/useMapQueryies.ts
@@ -1,0 +1,77 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { mapApi } from '../api/mapApi';
+import type { GetNearbyStoresParams } from '../api/types';
+
+export const QUERY_KEYS = {
+  STORES_LIST: 'stores-list',
+  STORE_DETAIL: 'store-detail',
+  FAVORITES: 'favorites',
+} as const;
+
+/**
+ * 매장 목록 조회 훅
+ *
+ */
+export const useStoreList = (params: GetNearbyStoresParams) => {
+  return useQuery({
+    queryKey: [QUERY_KEYS.STORES_LIST, params],
+    queryFn: () => mapApi.getStoreList(params),
+
+    // 지도 앱에 최적화된 기본 설정
+    staleTime: 5 * 60 * 1000, // 5분
+    enabled: params.lat !== 0 && params.lng !== 0, // 유효한 좌표일 때만 실행
+
+    // 사용자 경험을 위한 최소한의 설정
+    refetchOnWindowFocus: false,
+    retry: 2, // 네트워크 오류 시 2번 재시도
+  });
+};
+
+/**
+ * 매장 상세 정보 조회 훅
+ */
+export const useStoreDetail = (storeId: number | null) => {
+  return useQuery({
+    queryKey: [QUERY_KEYS.STORE_DETAIL, storeId],
+    queryFn: () => mapApi.getStoreDetail({ storeId: storeId! }),
+
+    // storeId가 유효할 때만 실행
+    enabled: !!storeId && storeId > 0,
+
+    // 상세 정보는 자주 변경되지 않으므로 더 긴 캐시
+    staleTime: 10 * 60 * 1000, // 10분
+  });
+};
+
+/**
+ * 즐겨찾기 토글 뮤테이션
+ *
+ * 추후 낙관적 업데이트 추가 예정
+ */
+export const useToggleFavorite = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: mapApi.toggleFavorite,
+
+    // 성공 시 관련 캐시 무효화
+    onSuccess: (data, variables) => {
+      // 해당 매장 상세 정보 갱신
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.STORE_DETAIL, variables.storeId],
+      });
+
+      // 매장 목록도 갱신 (즐겨찾기 상태 반영을 위해)
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.STORES_LIST],
+      });
+
+      console.log('즐겨찾기 업데이트 완료:', data);
+    },
+
+    // 에러 처리
+    onError: error => {
+      console.error('즐겨찾기 업데이트 실패:', error);
+    },
+  });
+};

--- a/src/features/kakao-map/store/LocationStore.ts
+++ b/src/features/kakao-map/store/LocationStore.ts
@@ -1,0 +1,129 @@
+import { create } from 'zustand';
+
+// 위치 타입
+interface Position {
+  lat: number;
+  lng: number;
+}
+
+// LocationStore 상태
+interface LocationState {
+  // 현재 위치
+  currentLocation: Position | null;
+
+  // 로딩 상태
+  isLoading: boolean;
+
+  // 에러 상태
+  error: string | null;
+
+  // 마커 표시 여부
+  showMarker: boolean;
+}
+
+// LocationStore 액션
+interface LocationActions {
+  // 현재 위치 가져오기
+  getCurrentLocation: () => Promise<void>;
+
+  // 마커 표시/숨김 토글
+  toggleMarker: () => void;
+
+  // 에러 클리어
+  clearError: () => void;
+}
+
+export type { LocationState, LocationActions };
+
+export const useLocationStore = create<LocationState & LocationActions>(
+  (set, get) => ({
+    currentLocation: null,
+    isLoading: false,
+    error: null,
+    showMarker: true,
+
+    getCurrentLocation: async () => {
+      // 이미 로딩 중이면 중복 실행 방지
+      if (get().isLoading) return;
+
+      set({ isLoading: true, error: null });
+
+      if (!navigator.geolocation) {
+        set({
+          isLoading: false,
+          error: '이 브라우저는 위치 서비스를 지원하지 않습니다.',
+        });
+        return;
+      }
+
+      try {
+        const position = await new Promise<GeolocationPosition>(
+          (resolve, reject) => {
+            navigator.geolocation.getCurrentPosition(resolve, reject, {
+              enableHighAccuracy: true, // 높은 정확도 요청
+              timeout: 10000, // 10초 타임아웃
+              maximumAge: 300000, // 5분간 캐시 허용
+            });
+          }
+        );
+
+        // 위치 정보 저장
+        set({
+          currentLocation: {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          },
+          isLoading: false,
+          error: null,
+        });
+      } catch (error) {
+        let errorMessage = '위치를 가져올 수 없습니다.';
+
+        if (error instanceof GeolocationPositionError) {
+          switch (error.code) {
+            case error.PERMISSION_DENIED:
+              errorMessage = '위치 접근 권한이 거부되었습니다.';
+              break;
+            case error.POSITION_UNAVAILABLE:
+              errorMessage = '위치 정보를 사용할 수 없습니다.';
+              break;
+            case error.TIMEOUT:
+              errorMessage = '위치 요청 시간이 초과되었습니다.';
+              break;
+          }
+        }
+
+        set({
+          isLoading: false,
+          error: errorMessage,
+        });
+      }
+    },
+
+    toggleMarker: () => {
+      set(state => ({
+        showMarker: !state.showMarker,
+      }));
+    },
+
+    clearError: () => {
+      set({ error: null });
+    },
+  })
+);
+
+// 선택적 Selectors (성능 최적화)
+// 현재 위치만 구독
+export const useCurrentLocation = () =>
+  useLocationStore(state => state.currentLocation);
+
+// 로딩 상태만 구독
+export const useLocationLoading = () =>
+  useLocationStore(state => state.isLoading);
+
+// 에러 상태만 구독
+export const useLocationError = () => useLocationStore(state => state.error);
+
+// 마커 표시 상태만 구독
+export const useShowLocationMarker = () =>
+  useLocationStore(state => state.showMarker);

--- a/src/features/kakao-map/store/StoreListStore.ts
+++ b/src/features/kakao-map/store/StoreListStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import type {
+  StoreDetail,
+  StoreSummary,
+  GetNearbyStoresParams,
+  GetStoreDetailParams,
+  ToggleFavoriteParams,
+} from '../api/types';
+
+/**
+ * 매장 목록 상태
+ */
+interface StoreListState {
+  stores: StoreSummary[];
+  selectedStoreId: number | null;
+  selectedStoreDetail: StoreDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchNearbyStores: (params: GetNearbyStoresParams) => Promise<void>;
+  fetchStoreDetail: (params: GetStoreDetailParams) => Promise<void>;
+  toggleFavorite: (params: ToggleFavoriteParams) => Promise<void>;
+  setSelectedStoreId: (storeId: number | null) => void;
+}
+
+export const useStoreListStore = create<StoreListState>(set => ({
+  stores: [],
+  selectedStoreId: null,
+  selectedStoreDetail: null,
+  isLoading: false,
+  error: null,
+
+  fetchNearbyStores: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      set({ stores: [], isLoading: false }); // 목업
+    } catch {
+      set({ error: '주변 매장 불러오기 실패', isLoading: false });
+    }
+  },
+
+  fetchStoreDetail: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      set({ selectedStoreDetail: null, isLoading: false }); // 목업
+    } catch {
+      set({ error: '매장 상세 불러오기 실패', isLoading: false });
+    }
+  },
+
+  toggleFavorite: async () => {
+    try {
+      console.log('즐겨찾기 토글');
+    } catch {
+      set({ error: '즐겨찾기 토글 실패' });
+    }
+  },
+
+  setSelectedStoreId: storeId => set({ selectedStoreId: storeId }),
+}));

--- a/src/features/kakao-map/types/category.ts
+++ b/src/features/kakao-map/types/category.ts
@@ -1,0 +1,138 @@
+// types/category.ts
+export type StoreCategory =
+  | 'cafe'
+  | 'restaurant'
+  | 'fastfood'
+  | 'bakery'
+  | 'convenience'
+  | 'beauty'
+  | 'pharmacy'
+  | 'electronics'
+  | 'default';
+
+export interface CategoryConfig {
+  name: string;
+  color: string;
+  ringColor: string; // 선택 상태일 때 사용할 색상
+  icon?: string;
+  description?: string;
+}
+
+// 카테고리별 시각적 설정을 중앙에서 관리
+export const CATEGORY_CONFIGS: Record<StoreCategory, CategoryConfig> = {
+  cafe: {
+    name: '카페',
+    color: 'bg-amber-500',
+    ringColor: 'ring-amber-300',
+    icon: '☕',
+    description: '커피 전문점',
+  },
+  restaurant: {
+    name: '음식점',
+    color: 'bg-green-500',
+    ringColor: 'ring-green-300',
+    icon: '🍽️',
+    description: '일반 음식점',
+  },
+  fastfood: {
+    name: '패스트푸드',
+    color: 'bg-red-500',
+    ringColor: 'ring-red-300',
+    icon: '🍔',
+    description: '패스트푸드 체인',
+  },
+  bakery: {
+    name: '베이커리',
+    color: 'bg-orange-500',
+    ringColor: 'ring-orange-300',
+    icon: '🥖',
+    description: '베이커리 및 디저트',
+  },
+  convenience: {
+    name: '편의점',
+    color: 'bg-blue-500',
+    ringColor: 'ring-blue-300',
+    icon: '🏪',
+    description: '편의점',
+  },
+  beauty: {
+    name: '뷰티',
+    color: 'bg-pink-500',
+    ringColor: 'ring-pink-300',
+    icon: '💄',
+    description: '화장품 및 뷰티',
+  },
+  pharmacy: {
+    name: '약국',
+    color: 'bg-emerald-500',
+    ringColor: 'ring-emerald-300',
+    icon: '💊',
+    description: '약국',
+  },
+  electronics: {
+    name: '전자제품',
+    color: 'bg-indigo-500',
+    ringColor: 'ring-indigo-300',
+    icon: '📱',
+    description: '전자제품 매장',
+  },
+  default: {
+    name: '기타',
+    color: 'bg-gray-500',
+    ringColor: 'ring-gray-300',
+    icon: '🏬',
+    description: '기타 매장',
+  },
+};
+
+export interface Category {
+  key: string;
+  name: string;
+  icon: string;
+  color?: string; // 카테고리별 색상 구분
+}
+
+export const CATEGORIES: Category[] = [
+  {
+    key: 'all',
+    name: '전체',
+    icon: '🏪',
+    color: 'bg-gray-500',
+  },
+  {
+    key: 'activity',
+    name: '액티비티',
+    icon: '🎯',
+    color: 'bg-blue-500',
+  },
+  {
+    key: 'beauty',
+    name: '뷰티/건강',
+    icon: '💄',
+    color: 'bg-pink-500',
+  },
+  {
+    key: 'shopping',
+    name: '쇼핑',
+    icon: '🛍️',
+    color: 'bg-purple-500',
+  },
+  {
+    key: 'lifestyle',
+    name: '생활/편의',
+    icon: '🏠',
+    color: 'bg-green-500',
+  },
+  {
+    key: 'food',
+    name: '푸드',
+    icon: '🍽️',
+    color: 'bg-orange-500',
+  },
+  {
+    key: 'culture',
+    name: '문화/여가',
+    icon: '🎭',
+    color: 'bg-indigo-500',
+  },
+];

--- a/src/features/kakao-map/types/store.ts
+++ b/src/features/kakao-map/types/store.ts
@@ -1,0 +1,16 @@
+export interface Store {
+  storeId: number; // 매장 고유 식별자 (숫자)
+  storeName: string; // 매장 이름
+  categoryName: string; // 카테고리 이름 (백엔드에서 정규화됨)
+  addressDetail: string; // 매장 상세 주소
+  benefit: string; // 매장 혜택 정보
+  logo_image: string; // 브랜드 로고 이미지 URL
+  brandName: string; // 브랜드 이름 (백엔드에서 정규화됨)
+  latitude: number; // 위도
+  longitude: number; // 경도
+}
+export interface FilterOption {
+  key: string;
+  label: string;
+  count?: number;
+}

--- a/src/features/kakao-map/utils/brandCategoryMapping.ts
+++ b/src/features/kakao-map/utils/brandCategoryMapping.ts
@@ -1,0 +1,70 @@
+// utils/brandCategoryMapping.ts
+export const BRAND_CATEGORY_MAPPING = {
+  food: {
+    brands: [
+      '스타벅스',
+      '투썸플레이스',
+      '이디야커피',
+      '파리바게뜨',
+      '뚜레쥬르',
+      '맥도날드',
+      '버거킹',
+      '롯데리아',
+    ],
+    patterns: [
+      /스타벅스/i,
+      /투썸/i,
+      /이디야/i,
+      /파리바게뜨/i,
+      /뚜레쥬르/i,
+      /맥도날드/i,
+      /버거킹/i,
+      /롯데리아/i,
+    ],
+  },
+  lifestyle: {
+    brands: ['GS25', 'CU', '세븐일레븐', '이마트24', '미니스톱'],
+    patterns: [/GS25/i, /CU/i, /세븐일레븐/i, /이마트24/i, /미니스톱/i],
+  },
+  beauty: {
+    brands: ['올리브영', '아리따움', '롭스', '왓슨스'],
+    patterns: [/올리브영/i, /아리따움/i, /롭스/i, /왓슨스/i],
+  },
+  shopping: {
+    brands: ['이마트', '홈플러스', '롯데마트', '코스트코'],
+    patterns: [/이마트/i, /홈플러스/i, /롯데마트/i, /코스트코/i],
+  },
+  culture: {
+    brands: ['CGV', '롯데시네마', '메가박스', '교보문고'],
+    patterns: [/CGV/i, /롯데시네마/i, /메가박스/i, /교보문고/i],
+  },
+  activity: {
+    brands: ['피트니스클럽', '골프장', '볼링장', '당구장'],
+    patterns: [/피트니스/i, /골프/i, /볼링/i, /당구/i],
+  },
+};
+
+// 매장 이름으로부터 카테고리를 추출하는 함수
+export const getStoreCategory = (storeName: string): string => {
+  for (const [category, config] of Object.entries(BRAND_CATEGORY_MAPPING)) {
+    const isMatch = config.patterns.some(pattern => pattern.test(storeName));
+    if (isMatch) {
+      return category;
+    }
+  }
+  return 'lifestyle'; // 기본 카테고리
+};
+
+// 특정 카테고리의 브랜드 목록을 가져오는 함수
+export const getBrandsByCategory = (categoryKey: string): string[] => {
+  if (categoryKey === 'all') {
+    // 전체 선택 시 모든 브랜드 반환
+    return Object.values(BRAND_CATEGORY_MAPPING).flatMap(
+      config => config.brands
+    );
+  }
+
+  const categoryConfig =
+    BRAND_CATEGORY_MAPPING[categoryKey as keyof typeof BRAND_CATEGORY_MAPPING];
+  return categoryConfig ? categoryConfig.brands : [];
+};

--- a/src/features/kakao-map/utils/brandImageMapper.ts
+++ b/src/features/kakao-map/utils/brandImageMapper.ts
@@ -1,0 +1,17 @@
+export const getBrandImagePath = (storeName: string): string => {
+  // 매장명에서 브랜드명 추출 (예: "스타벅스 강남점" → "스타벅스")
+  const brandName = storeName.split(' ')[0];
+  // 브랜드별 이미지 매핑
+  const brandImageMap: Record<string, string> = {
+    굽네치킨: '/images/brands/굽네치킨.png',
+    파리바게뜨: '/images/brands/파리바게뜨.png',
+    롯데시네마: '/images/brands/롯데시네마.png',
+    베스킨라빈스: '/images/brands/베스킨라빈스.png',
+    원더파크: '/images/brands/원더파크.png',
+    CGV: '/images/brands/CGV.png',
+    GS25: '/images/brands/GS25.png',
+    뚜레쥬르: '/images/brands/뚜레쥬르.png',
+  };
+  // 매핑된 이미지가 있으면 반환, 없으면 기본 이미지
+  return brandImageMap[brandName] || '/images/brands/default.png';
+};

--- a/src/features/kakao-map/utils/categoryMapper.ts
+++ b/src/features/kakao-map/utils/categoryMapper.ts
@@ -1,0 +1,116 @@
+import type { StoreCategory } from '../types/category';
+
+interface BrandCategoryMapping {
+  patterns: RegExp[];
+  category: StoreCategory;
+}
+
+// 브랜드 패턴과 카테고리 매핑 정의
+const BRAND_MAPPINGS: BrandCategoryMapping[] = [
+  // 카페 카테고리
+  {
+    patterns: [/스타벅스/i, /starbucks/i],
+    category: 'cafe',
+  },
+  {
+    patterns: [/투썸/i, /twosome/i, /2some/i],
+    category: 'cafe',
+  },
+  {
+    patterns: [/이디야/i, /ediya/i],
+    category: 'cafe',
+  },
+  {
+    patterns: [/커피빈/i, /coffee\s*bean/i],
+    category: 'cafe',
+  },
+  {
+    patterns: [/할리스/i, /hollys/i],
+    category: 'cafe',
+  },
+
+  // 패스트푸드 카테고리
+  {
+    patterns: [/맥도날드/i, /mcdonald/i],
+    category: 'fastfood',
+  },
+  {
+    patterns: [/버거킹/i, /burger\s*king/i],
+    category: 'fastfood',
+  },
+  {
+    patterns: [/KFC/i, /케이에프씨/i],
+    category: 'fastfood',
+  },
+  {
+    patterns: [/롯데리아/i, /lotteria/i],
+    category: 'fastfood',
+  },
+
+  // 베이커리 카테고리
+  {
+    patterns: [/파리바게뜨/i, /paris\s*baguette/i],
+    category: 'bakery',
+  },
+  {
+    patterns: [/뚜레쥬르/i, /tous\s*les\s*jours/i],
+    category: 'bakery',
+  },
+  {
+    patterns: [/던킨/i, /dunkin/i],
+    category: 'bakery',
+  },
+
+  // 편의점 카테고리
+  {
+    patterns: [/GS25/i, /지에스25/i],
+    category: 'convenience',
+  },
+  {
+    patterns: [/CU/i, /씨유/i],
+    category: 'convenience',
+  },
+  {
+    patterns: [/세븐일레븐/i, /7-eleven/i, /7eleven/i],
+    category: 'convenience',
+  },
+
+  // 뷰티 카테고리
+  {
+    patterns: [/올리브영/i, /olive\s*young/i],
+    category: 'beauty',
+  },
+  {
+    patterns: [/아리따움/i, /aritaum/i],
+    category: 'beauty',
+  },
+];
+
+// 매장명으로부터 카테고리를 추출하는 함수
+export const getStoreCategory = (storeName: string): StoreCategory => {
+  // 정의된 패턴들과 매칭 시도
+  for (const mapping of BRAND_MAPPINGS) {
+    const isMatch = mapping.patterns.some(pattern => pattern.test(storeName));
+    if (isMatch) {
+      return mapping.category;
+    }
+  }
+
+  // 매칭되지 않으면 기본 카테고리 반환
+  return 'default';
+};
+
+// 카테고리별 매장 개수를 계산하는 유틸리티 함수
+export const getCategoryStats = (stores: Array<{ name: string }>) => {
+  const stats: Record<StoreCategory, number> = {} as Record<
+    StoreCategory,
+    number
+  >;
+
+  stores.forEach(store => {
+    const category = getStoreCategory(store.name);
+    stats[category] = (stats[category] || 0) + 1;
+  });
+
+  return stats;
+};

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -1,0 +1,359 @@
+import { useState, useEffect } from 'react';
+import useKakaoLoader from '@/features/kakao-map/hooks/useKakaoLoader';
+import LocationButton from '@/features/kakao-map/components/LocationButton';
+import MapWithMarkers from '@/features/kakao-map/components/MapWithMarkers';
+import MapTopControls from '@/features/kakao-map/components/MapTopControls';
+import { PersistentBottomSheet } from '@features/kakao-map/components/PersistentBottomSheet';
+import StoreListContent from '@/features/kakao-map/components/StoreListContent';
+import CategorySelectContent from '@features/kakao-map/components/steps/CategorySelectContent';
+import BrandSelectContent from '@features/kakao-map/components/steps/BrandSelectContent';
+import { useLocationStore } from '@features/kakao-map/store/LocationStore';
+import type {
+  LocationState,
+  LocationActions,
+} from '@features/kakao-map/store/LocationStore';
+import type { Store } from '@/features/kakao-map/types/store';
+
+/**
+ * 바텀시트에서 사용할 수 있는 스텝들을 정의합니다.
+ * category와 brand 스텝을 추가했습니다.
+ */
+type BottomSheetStep = 'list' | 'category' | 'brand';
+
+/**
+ * 지도 페이지의 메인 컴포넌트입니다.
+ * 2단계 필터링 시스템을 지원합니다.
+ */
+function MapPage() {
+  // 카카오맵 SDK 초기화
+  useKakaoLoader();
+
+  /**
+   * 검색 관련 상태
+   */
+  const [searchValue, setSearchValue] = useState('');
+  const [activeFilter, setActiveFilter] = useState('');
+
+  /**
+   * 바텀시트 상태 관리
+   */
+  const [currentBottomSheetStep, setCurrentBottomSheetStep] =
+    useState<BottomSheetStep>('list');
+
+  /**
+   * 필터 관련 상태 (새로 추가)
+   * 실제 필터링 로직은 나중에 추가하고, 지금은 UI 동작만 구현
+   */
+  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [selectedBrand, setSelectedBrand] = useState<string>('');
+
+  /**
+   * 지도 중심점 상태
+   */
+  const [mapCenter, setMapCenter] = useState<{ lat: number; lng: number }>({
+    lat: 37.54699,
+    lng: 127.09598,
+  });
+
+  /**
+   * 실제 서비스에서 사용할 수 있는 다양한 매장 데이터
+   */
+  const [storeList] = useState<Store[]>([
+    {
+      storeId: 1,
+      storeName: '뚜레쥬르 강남점',
+      addressDetail: '서울시 강남구 테헤란로 123',
+      benefit: '케이크 30% 할인',
+      logo_image: '/images/brands/tous_les_jours.png',
+      brandName: '뚜레쥬르',
+      latitude: 37.51701,
+      longitude: 127.04799,
+      categoryName: '푸드',
+    },
+    {
+      storeId: 3,
+      storeName: '베스킨라빈스 삼성점',
+      addressDetail: '서울시 강남구 삼성로 77',
+      benefit: '아이스크림 1+1',
+      logo_image: '/images/brands/baskin_robbins.png',
+      brandName: '베스킨라빈스',
+      latitude: 37.50129,
+      longitude: 127.03197,
+      categoryName: '푸드',
+    },
+    {
+      storeId: 4,
+      storeName: '파리바게뜨 선릉점',
+      addressDetail: '서울시 강남구 선릉로 88',
+      benefit: '빵 구매시 음료 무료',
+      logo_image: '/images/brands/paris_baguette.png',
+      brandName: '파리바게뜨',
+      latitude: 37.50445,
+      longitude: 127.04893,
+      categoryName: '푸드',
+    },
+    {
+      storeId: 5,
+      storeName: 'GS25 역삼점',
+      addressDetail: '서울시 강남구 역삼동 123-45',
+      benefit: '생필품 10% 할인',
+      logo_image: '/images/brands/gs25.png',
+      brandName: 'GS25',
+      latitude: 37.49933,
+      longitude: 127.03656,
+      categoryName: '생활/편의',
+    },
+  ]);
+
+  const currentLocation = useLocationStore(
+    (state: LocationState & LocationActions) => state.currentLocation
+  );
+  const isLocationLoading = useLocationStore(
+    (state: LocationState & LocationActions) => state.isLoading
+  );
+  const locationError = useLocationStore(
+    (state: LocationState & LocationActions) => state.error
+  );
+  const getCurrentLocation = useLocationStore(
+    (state: LocationState & LocationActions) => state.getCurrentLocation
+  );
+
+  /**
+   * 카테고리별 표시 이름 매핑
+   */
+  const getCategoryDisplayName = (categoryKey: string): string => {
+    const categoryNames: Record<string, string> = {
+      activity: '액티비티',
+      beauty: '뷰티/건강',
+      shopping: '쇼핑',
+      lifestyle: '생활/편의',
+      food: '푸드',
+      culture: '문화/여가',
+      education: '교육',
+      travel: '여행/교통',
+    };
+    return categoryNames[categoryKey] || categoryKey;
+  };
+
+  /**
+   * 카테고리별 브랜드 목록 매핑
+   */
+  const getBrandsByCategory = (category: string): string[] => {
+    const brandMapping: Record<string, string[]> = {
+      lifestyle: ['GS25', '펫생각', '셀로', '다락'],
+      food: ['스타벅스', '투썸플레이스', '이디야', '파리바게뜨'],
+      beauty: ['올리브영', '아리따움', '롭스', '왓슨스'],
+      shopping: ['이마트', '홈플러스', '롯데마트', '코스트코'],
+      culture: ['CGV', '롯데시네마', '메가박스', '교보문고'],
+      activity: ['피트니스클럽', '골프장', '볼링장', '당구장'],
+      education: ['해커스', '시원스쿨', '에듀윌', '종로학원'],
+      travel: ['하나투어', '모두투어', '노랑풍선', '온라인투어'],
+    };
+    return brandMapping[category] || [];
+  };
+
+  /**
+   * 검색 관련 이벤트 핸들러
+   */
+  const handleSearch = (value: string) => {
+    console.log('🔍 검색 실행:', value);
+    // TODO: 실제 검색 API 연동 시 구현
+  };
+
+  const handleSearchCancel = () => {
+    console.log('❌ 검색 취소');
+    setSearchValue('');
+  };
+
+  /**
+   * 2단계 필터링 이벤트 핸들러들
+   */
+  const handleShowFilter = () => {
+    console.log('🔍 필터 설정 시작 - 카테고리 선택 화면으로 이동');
+    setCurrentBottomSheetStep('category');
+  };
+
+  const handleCategorySelect = (categoryKey: string) => {
+    console.log('📂 카테고리 선택:', categoryKey);
+    setSelectedCategory(categoryKey);
+    // 카테고리 선택 후 브랜드 선택 화면으로 이동
+    setCurrentBottomSheetStep('brand');
+  };
+
+  const handleBrandSelect = (brandName: string) => {
+    console.log('🏢 브랜드 선택:', brandName);
+    setSelectedBrand(brandName);
+    // 브랜드 선택 후 결과 확인을 위해 목록 화면으로 이동
+    setCurrentBottomSheetStep('list');
+
+    // TODO: 여기서 실제 필터링 로직을 적용
+    // 예: filterStores(selectedCategory, brandName);
+  };
+
+  const handleBackToCategory = () => {
+    console.log('⬅️ 카테고리 선택 화면으로 돌아가기');
+    setCurrentBottomSheetStep('category');
+  };
+
+  const handleBottomSheetStepChange = (step: string) => {
+    console.log('📱 바텀시트 스텝 변경:', step);
+    setCurrentBottomSheetStep(step as BottomSheetStep);
+  };
+
+  /**
+   * 매장 관련 이벤트 핸들러
+   */
+  const handleStoreClick = (store: Store) => {
+    console.log('🏪 매장 선택:', store.storeName);
+
+    // 지도를 해당 매장으로 이동
+    setMapCenter({ lat: store.latitude, lng: store.longitude });
+
+    // 매장 클릭 시 리스트 화면으로 돌아가기
+    if (currentBottomSheetStep !== 'list') {
+      setCurrentBottomSheetStep('list');
+    }
+  };
+
+  /**
+   * 위치 관련 이벤트 핸들러
+   */
+  const handleLocationClick = async () => {
+    console.log('📍 내 위치 버튼 클릭');
+
+    try {
+      await getCurrentLocation();
+      if (currentLocation) {
+        console.log('📍 내 위치로 지도 이동:', currentLocation);
+        setMapCenter(currentLocation);
+      }
+    } catch (error) {
+      console.error('위치 가져오기 실패:', error);
+    }
+  };
+
+  /**
+   * 상단 필터 변경 핸들러
+   */
+  const handleTopFilterChange = (filterValue: string) => {
+    console.log('🔍 상단 필터 변경:', filterValue);
+    setActiveFilter(filterValue);
+    // TODO: 실제 필터링 로직 구현
+  };
+
+  /**
+   * 사용자 위치가 업데이트될 때 지도 중심을 자동으로 이동
+   */
+  useEffect(() => {
+    if (currentLocation) {
+      console.log('📍 위치 업데이트 감지, 지도 중심 이동:', currentLocation);
+      setMapCenter(currentLocation);
+    }
+  }, [currentLocation]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('📱 바텀시트 상태:', {
+        currentStep: currentBottomSheetStep,
+        selectedCategory,
+        selectedBrand,
+        timestamp: new Date().toLocaleTimeString(),
+      });
+    }
+  }, [currentBottomSheetStep, selectedCategory, selectedBrand]);
+
+  /**
+   * 바텀시트 스텝 정의 (3단계로 확장)
+   */
+  const bottomSheetSteps = [
+    {
+      key: 'list',
+      title: '주변 제휴 매장',
+      subtitle:
+        selectedCategory || selectedBrand
+          ? `${getCategoryDisplayName(selectedCategory)}${selectedBrand ? ' > ' + selectedBrand : ''}`
+          : undefined,
+      showFilterButton: true,
+      onFilterClick: handleShowFilter,
+      content: (
+        <StoreListContent
+          stores={storeList}
+          onFilterClick={handleShowFilter}
+          onStoreClick={handleStoreClick}
+        />
+      ),
+    },
+    {
+      key: 'category',
+      title: '필터',
+      showBackButton: true,
+      content: (
+        <CategorySelectContent
+          selectedCategory={selectedCategory}
+          onCategorySelect={handleCategorySelect}
+        />
+      ),
+    },
+    {
+      key: 'brand',
+      title: '필터',
+      showBackButton: true,
+      content: (
+        <BrandSelectContent
+          categoryKey={selectedCategory}
+          categoryDisplayName={getCategoryDisplayName(selectedCategory)}
+          brands={getBrandsByCategory(selectedCategory)}
+          selectedBrand={selectedBrand}
+          onBrandSelect={handleBrandSelect}
+          onBack={handleBackToCategory}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div className="h-screen flex flex-col">
+      <div className="flex-1 relative">
+        <MapWithMarkers
+          center={mapCenter}
+          stores={storeList}
+          currentLocation={currentLocation}
+        />
+
+        <MapTopControls
+          searchValue={searchValue}
+          onSearchValueChange={setSearchValue}
+          onSearch={handleSearch}
+          onSearchCancel={handleSearchCancel}
+          activeFilter={activeFilter}
+          onFilterChange={handleTopFilterChange}
+        />
+
+        <div className="absolute bottom-32 right-4 z-10">
+          <LocationButton
+            onClick={handleLocationClick}
+            isLoading={isLocationLoading}
+          />
+        </div>
+
+        {locationError && (
+          <div className="absolute top-0 left-0 right-0 bg-red-100 text-red-600 text-center py-2 z-50">
+            <span className="text-sm font-medium">⚠️ {locationError}</span>
+          </div>
+        )}
+      </div>
+
+      <PersistentBottomSheet
+        steps={bottomSheetSteps}
+        currentStepKey={currentBottomSheetStep}
+        onStepChange={handleBottomSheetStepChange}
+        minHeight={80}
+        maxHeight={500}
+        defaultExpanded={true}
+        bottomNavHeight={30}
+      />
+    </div>
+  );
+}
+
+export default MapPage;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -12,6 +12,7 @@ import {
   Routes,
   useLocation,
 } from 'react-router-dom';
+import MapPage from '@pages/map/MapPage';
 
 const Layout = () => {
   const { pathname } = useLocation();
@@ -26,9 +27,14 @@ const Layout = () => {
     pathname as (typeof visibleBottomNavRoutes)[number]
   );
 
+  const isMap = pathname === PATH.MAP;
+
   return (
-    <div className="w-full h-full flex flex-col">
-      <BaseLayout>
+    <div
+      className={`w-full h-full flex flex-col ${isMap ? 'items-stretch justify-start' : 'justify-center'}`}
+      style={isMap ? { minWidth: 0 } : undefined}
+    >
+      <BaseLayout isMap={isMap}>
         <Outlet />
       </BaseLayout>
       {showBottomNav && <BottomNavigation />}
@@ -42,11 +48,11 @@ export const AppRoutes = () => {
       <Routes>
         <Route element={<Layout />}>
           <Route path={PATH.HOME} element={<HomePage />} />
-          <Route path={PATH.MAP} element={<div>mapPage</div>} />
           <Route path={PATH.BENEFIT} element={<BenefitPage />} />
           <Route path={PATH.MYPAGE} element={<div>myPage</div>} />
           <Route path={PATH.EXTRA_INFO} element={<ExtraInfo />} />
           <Route path={PATH.LOGIN} element={<div>loginPage</div>} />
+          <Route path={PATH.MAP} element={<MapPage />} />
         </Route>
       </Routes>
 

--- a/src/shared/components/BaseLayout.tsx
+++ b/src/shared/components/BaseLayout.tsx
@@ -1,10 +1,17 @@
 interface BaseLayoutProps {
   children: React.ReactNode;
+  isMap?: boolean;
 }
 
-const BaseLayout = ({ children }: BaseLayoutProps) => {
+const BaseLayout = ({ children, isMap = false }: BaseLayoutProps) => {
   return (
-    <div className="flex-1 bg-white scrollbar-hidden overflow-hidden px-4 pt-[60px] pb-[40px] w-full max-w-[360px] mx-auto h-full overflow-y-auto">
+    <div
+      className={
+        isMap
+          ? 'flex-1 bg-white scrollbar-hidden overflow-hidden w-full h-full min-w-0'
+          : 'flex-1 bg-white scrollbar-hidden overflow-hidden px-4 pt-[60px] pb-[40px] w-full max-w-[360px] mx-auto h-full overflow-y-auto'
+      }
+    >
       {children}
     </div>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-
+    "types": ["kakao.maps.d.ts"],
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,7 +143,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/runtime@^7.12.5":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.22.15":
   version "7.27.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
@@ -2977,6 +2977,11 @@ jsonfile@^6.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+kakao.maps.d.ts@^0.1.39:
+  version "0.1.40"
+  resolved "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz"
+  integrity sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"
@@ -3516,7 +3521,7 @@ react-docgen@^8.0.0:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-"react-dom@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom@^18 || ^19 || ^19.0.0-rc", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react-dom@^19.1.0, react-dom@>=16.8.0, react-dom@>=18:
+"react-dom@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom@^18 || ^19 || ^19.0.0-rc", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react-dom@^19.1.0, react-dom@>=16.8, react-dom@>=16.8.0, react-dom@>=18:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
   integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
@@ -3537,6 +3542,14 @@ react-icons@^5.5.0:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-kakao-maps-sdk@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.2.0.tgz"
+  integrity sha512-ptyHhtSbvyza+9IAf6TXjE4ZhwwLbXR6avgNM2ju5xed2+fDwJ+gJDFSqhfsKbvFn9K9+3I+dY3JrqruwsGNBw==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    kakao.maps.d.ts "^0.1.39"
 
 "react-redux@^7.2.1 || ^8.1.3 || ^9.0.0", "react-redux@8.x.x || 9.x.x":
   version "9.2.0"
@@ -3598,7 +3611,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react@*, "react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.9.0 || ^17.0.0 || ^18 || ^19", "react@^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react@^19.1.0, "react@>= 16.8.0", react@>=16, react@>=16.8.0, react@>=18, react@>=18.0.0:
+react@*, "react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.9.0 || ^17.0.0 || ^18 || ^19", "react@^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react@^19.1.0, "react@>= 16.8.0", react@>=16, react@>=16.8, react@>=16.8.0, react@>=18, react@>=18.0.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react/-/react-19.1.0.tgz"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==


### PR DESCRIPTION
<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현
 -->

# 개요

# 지도 기반 매장 검색 시스템 - 컴포넌트 아키텍처 및 기능 명세

## 개요

본 문서는 React 기반 지도 매장 검색 시스템의 컴포넌트 설계와 구현 내용을 다룹니다. 이 시스템은 사용자 위치 기반 매장 탐색, 다단계 필터링, 그리고 직관적인 모바일 UI를 제공하는 것을 목표로 합니다.

## 시스템 아키텍처

### 설계 원칙

시스템은 관심사 분리 원칙에 따라 세 개의 주요 레이어로 구성되었습니다. 데이터 관리 레이어는 서버 통신과 캐싱을 전담하고, UI 컴포넌트 레이어는 사용자 인터페이스 렌더링을 처리합니다. 상태 관리 레이어는 애플리케이션의 전역 상태를 조율하는 역할을 수행합니다.

### 기술 스택

카카오 지도 API를 활용한 지도 시각화, TanStack Query를 통한 서버 상태 관리, 그리고 Zustand를 이용한 클라이언트 상태 관리 구조를 채택했습니다. Framer Motion을 통해 바텀시트와 같은 모바일 특화 UI 컴포넌트의 애니메이션을 구현했습니다.

## 핵심 컴포넌트 분석

### 데이터 관리 컴포넌트

**useStoreList 훅**
사용자 위치를 기반으로 매장 목록을 조회하는 핵심 훅입니다. 위도, 경도, 검색 반경을 파라미터로 받아 해당 지역의 매장 데이터를 반환합니다. 동일한 지역에 대한 중복 요청을 방지하는 스마트 캐싱 기능을 포함하여 네트워크 사용량을 최적화합니다.

**useStoreDetail 훅**
개별 매장의 상세 정보 조회를 처리합니다. 매장 정보의 변경 빈도가 낮다는 특성을 고려하여 긴 캐시 시간을 적용했습니다. 매장이 선택되지 않은 상태에서는 불필요한 API 호출을 차단하는 안전장치를 포함합니다.

**useToggleFavorite 훅**
즐겨찾기 상태 변경을 관리하는 뮤테이션 훅입니다. 성공 시 관련된 모든 캐시 데이터를 자동으로 무효화하여 UI 전반의 데이터 일관성을 보장합니다.

### 지도 및 시각화 컴포넌트
<img width="1511" height="765" alt="image" src="https://github.com/user-attachments/assets/cc3401e8-9b37-42ba-b2f8-8bece1590250" />
<img width="1511" height="765" alt="image" src="https://github.com/user-attachments/assets/f2ce1e55-1afc-45ac-9b5d-7250a9d4acb0" />

**MapWithMarkers**
카카오 지도 API를 활용하여 매장 위치를 시각적으로 표현하는 컴포넌트입니다. 매장 데이터 배열을 받아 각 매장을 개별 마커로 표시하며, 사용자의 현재 위치도 구별되는 마커로 표현합니다.

**BrandMarker**
개별 매장 마커의 시각적 표현을 담당합니다. 브랜드별로 구분되는 마커를 생성하며, 선택 상태와 프로모션 여부에 따라 다른 시각적 피드백을 제공합니다.

**LocationButton**
사용자의 현재 위치로 지도를 이동시키는 기능을 제공합니다. 위치 조회 중인 상태를 시각적으로 표시하며, 위치 권한이나 네트워크 오류 시 적절한 피드백을 제공합니다.

### 바텀시트 시스템
<img width="1511" height="765" alt="image" src="https://github.com/user-attachments/assets/9727be4f-0608-4f05-952b-275fda50e968" />

**PersistentBottomSheet**
모바일 환경에 최적화된 하단 패널 시스템의 핵심 컴포넌트입니다. 여러 단계의 화면 전환을 매끄럽게 처리하며, 각 단계별로 다른 콘텐츠와 네비게이션 옵션을 제공합니다.
<img width="1511" height="765" alt="image" src="https://github.com/user-attachments/assets/5100a46e-ddd9-47a6-a271-71a9c6e45a7f" />

**StoreListContent**
매장 목록을 카드 형태로 표시하는 컴포넌트입니다. 각 매장의 기본 정보와 혜택을 요약하여 보여주며, 필터 버튼과의 연동을 통해 필터링 화면으로의 네비게이션을 처리합니다.
<img width="1511" height="765" alt="image" src="https://github.com/user-attachments/assets/59dac45a-a4e5-45f6-b41d-b08af3baff98" />

**CategorySelectContent**
2단계 필터링 시스템의 첫 번째 단계를 담당합니다. 8개의 주요 카테고리를 2x4 그리드 형태로 배치하며, 각 카테고리는 직관적인 아이콘과 함께 표시됩니다.

**BrandSelectContent**
카테고리 선택 후 해당 카테고리의 브랜드 목록을 표시합니다. 선택된 카테고리 정보를 헤더에 표시하고, 뒤로가기 기능을 제공합니다.

### 상위 제어 컴포넌트

**MapTopControls**
지도 상단의 검색 및 필터 인터페이스를 통합 관리합니다. 검색 입력, 지역별 필터 드롭다운, 필터 탭 등의 요소들을 조율합니다.

**MapPage**
전체 시스템의 오케스트레이터 역할을 수행합니다. 모든 하위 컴포넌트의 상태를 조율하고, 사용자 이벤트에 따른 적절한 액션을 결정합니다.

## 상태 관리 체계

### LocationStore

사용자의 위치 정보와 관련된 모든 상태를 중앙집중식으로 관리합니다. GPS 위치 조회, 위치 권한 처리, 오류 상태 관리를 담당하며, 여러 컴포넌트에서 동일한 위치 정보를 일관성 있게 사용할 수 있도록 보장합니다.

### StoreListStore

매장 관련 비즈니스 로직을 캡슐화할 준비가 되어 있는 스토어입니다. 현재는 기본 구조만 제공되며, 향후 복잡한 필터링 로직이나 매장 관리 기능이 추가될 때 활용할 예정입니다.

## 데이터 플로우 및 상호작용

### 매장 검색 플로우

사용자의 위치 정보가 LocationStore에서 MapPage로 전달됩니다. MapPage는 이 정보를 활용하여 useStoreList 훅을 통해 매장 데이터를 조회합니다. 조회된 데이터는 MapWithMarkers와 StoreListContent에 동시에 전달되어 지도 마커와 목록 카드로 각각 표시됩니다.

### 필터링 플로우

사용자가 StoreListContent의 필터 버튼을 클릭하면 MapPage의 상태가 변경되어 바텀시트가 CategorySelectContent를 표시합니다. 카테고리 선택 시 MapPage는 선택 정보를 저장하고 BrandSelectContent로 전환합니다. 브랜드 선택 완료 시 필터 조건이 적용되어 매장 목록이 업데이트됩니다.

### 매장 상호작용 플로우

매장 마커나 목록 카드 클릭 시 해당 매장 ID가 MapPage로 전달됩니다. useStoreDetail 훅을 통해 상세 정보를 조회하고, 즐겨찾기 버튼 클릭 시 useToggleFavorite 훅이 실행되어 서버 상태를 변경합니다. 관련된 모든 캐시가 자동으로 업데이트됩니다.

## 주요 동작 시나리오

### 앱 초기 실행

앱이 시작되면 LocationStore가 사용자의 위치 권한을 요청하고 현재 위치를 조회합니다. 위치 정보가 확보되면 MapPage가 해당 위치 중심으로 지도를 표시하고, useStoreList 훅을 통해 주변 매장을 자동으로 로드합니다. 로드된 매장들은 지도 마커와 바텀시트 목록에 동시에 표시됩니다.

### 필터 적용

사용자가 필터 버튼을 클릭하면 바텀시트가 카테고리 선택 화면으로 전환됩니다. 카테고리 선택 시 자동으로 브랜드 선택 화면으로 이동하며, 브랜드 선택 또는 건너뛰기를 통해 필터가 적용된 매장 목록으로 돌아갑니다. 이 과정에서 지도의 마커도 필터 조건에 맞게 업데이트됩니다.

### 매장 상세 조회

사용자가 매장을 선택하면 해당 매장 중심으로 지도가 이동하고, 동시에 상세 정보가 로드됩니다. 상세 정보는 별도의 팝업이나 확장된 카드 형태로 표시되며, 즐겨찾기 상태 변경 시 모든 관련 화면이 즉시 업데이트됩니다.


<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
