### PR TITLE
[FEAT][UHYU-202] 로그인 버튼 임시구현

### DIFF
--- a/src/features/home/components/LoginButton.tsx
+++ b/src/features/home/components/LoginButton.tsx
@@ -1,0 +1,20 @@
+// src/features/auth/components/LoginButton.tsx
+
+export const LoginButton = () => {
+  const handleLogin = () => {
+    const kakaoAuthUrl = `${import.meta.env.VITE_KAKAO_LOGIN_URL}`;
+    console.log('로그인 버튼 클릭');
+    console.log(import.meta.env.VITE_KAKAO_LOGIN_URL);
+
+    window.location.href = kakaoAuthUrl;
+  };
+
+  return (
+    <button
+      onClick={handleLogin}
+      className="w-full bg-yellow-400 hover:bg-yellow-500 text-white py-3 rounded-xl font-bold"
+    >
+      카카오 로그인
+    </button>
+  );
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,15 +1,18 @@
-import { DragBottomSheet } from '@/shared/components';
 import {
   AuthHomeSheetContent,
   GuestHomeSheetContent,
 } from '@features/home/components';
+import { LoginButton } from '@home/components/LoginButton';
+
+import { DragBottomSheet } from '@/shared/components';
 
 const HomePage = () => {
   const isLoggedIn = true; // 로그인 여부를 확인하는 로직이 필요합니다.
   return (
     <div>
-      <div>지도 부분</div>
+      <div></div>
       <DragBottomSheet>
+        <LoginButton />
         {isLoggedIn ? <AuthHomeSheetContent /> : <GuestHomeSheetContent />}
       </DragBottomSheet>
     </div>


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
로그인 버튼 임시 구현
env 파일에 있는 VITE_KAKAO_LOGIN_URL 로 가게 했음!

# 현재 UI 캡처
|유휴|카카오로그인페이지|
|:--:|:--:|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/c00846ac-0ae7-4baa-8b97-504041708d5f" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/73150607-8f8c-403c-afc7-af6d9707b1cd" />|



## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
