### PR TITLE
[FEAT][UHYU-213] 즐겨찾기 + My Map 목록 조회 MSW 및 기능

### DIFF
--- a/src/features/benefit/api/mockData.ts
+++ b/src/features/benefit/api/mockData.ts
@@ -12,7 +12,7 @@ interface BrandMock extends Brand {
 /**
  * 목데이터: 브랜드 정보
  */
-export const allBrands: BrandMock[] = [
+export const mockAllBrands: BrandMock[] = [
   {
     brandId: 101,
     brandName: '굽네치킨',

--- a/src/features/benefit/api/mockData.ts
+++ b/src/features/benefit/api/mockData.ts
@@ -12,7 +12,7 @@ interface BrandMock extends Brand {
 /**
  * 목데이터: 브랜드 정보
  */
-export const mockAllBrands: BrandMock[] = [
+export const MOCK_ALL_BRANDS: BrandMock[] = [
   {
     brandId: 101,
     brandName: '굽네치킨',
@@ -90,7 +90,7 @@ export const mockAllBrands: BrandMock[] = [
 /**
  * 목데이터: 브랜드 상세 정보
  */
-export const mockBrandDetails: BrandDetailRes[] = [
+export const MOCK_BRAND_DETAILS: BrandDetailRes[] = [
   {
     brandId: 101,
     brandName: '굽네치킨',

--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import { MyMapList } from '@mymap/components/mymap-list';
 import { FaFilter } from 'react-icons/fa';
-
-import { MapDragBottomSheet } from './MapDragBottomSheet';
 
 import { useMapData } from '../hooks/useMapData';
 import { useMapInteraction } from '../hooks/useMapInteraction';
 import { useMapUI } from '../hooks/useMapUI';
+import { MapDragBottomSheet } from './MapDragBottomSheet';
 import StoreListContent from './layout/StoreListContent';
 import BrandSelectContent from './layout/steps/BrandSelectContent';
 import CategorySelectContent from './layout/steps/CategorySelectContent';
@@ -18,6 +18,7 @@ export const BottomSheetContainer: React.FC = () => {
     selectedCategory,
     selectedBrand,
     currentBottomSheetStep,
+    showMymap,
     showFilter,
     selectCategoryAndNavigate,
     selectBrandAndReturn,
@@ -32,64 +33,140 @@ export const BottomSheetContainer: React.FC = () => {
     console.log(`지도 선택됨: ${id}`);
     // 선택된 지도 상세 보기 또는 이동 처리
   };
+  const getCurrentStepContent = () => {
+    switch (currentBottomSheetStep) {
+      case 'list':
+        return (
+          <div onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div className="flex-1">
+                <h2 className="text-lg font-bold text-gray-900">
+                  주변 제휴 매장
+                </h2>
+                {(selectedCategory || selectedBrand) && (
+                  <p className="text-sm text-gray-500 mt-1">
+                    {selectedCategory}
+                    {selectedBrand ? ' > ' + selectedBrand : ''}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-row gap-2">
+                {/* mymap */}
+                <div className="flex items-center gap-2">
+                  <button
+                    className="flex items-center gap-1.5 px-3 py-2 text-sm font-bold text-black hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 border border-light-gray shadow-sm hover:shadow-md"
+                    onClick={e => {
+                      e.stopPropagation();
+                      showMymap();
+                    }}
+                    aria-label="MyMap으로 이동"
+                  >
+                    <span>My Map</span>
+                  </button>
+                </div>
+                {/* filter */}
+                <div className="flex items-center gap-2">
+                  <button
+                    className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-black hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 border border-light-gray hover:border-blue-300 shadow-sm hover:shadow-md"
+                    onClick={e => {
+                      e.stopPropagation();
+                      showFilter();
+                    }}
+                    aria-label="필터 설정"
+                  >
+                    <FaFilter className="w-3.5 h-3.5" />
+                    <span>필터</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <StoreListContent
+              stores={stores}
+              onFilterClick={showFilter}
+              onStoreClick={handleStoreSelect}
+            />
+          </div>
+        );
+      case 'mymap':
+        return (
+          <div onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div className="flex-1">
+                <h2 className="text-lg font-bold text-gray-900">필터</h2>
+              </div>
+              <button
+                className="px-3 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md"
+                onClick={e => {
+                  e.stopPropagation();
+                  backToList();
+                }}
+                aria-label="이전 화면으로 돌아가기"
+              >
+                뒤로
+              </button>
+            </div>
+            <MyMapList
+              onCreateNewMap={handleCreateNewMap}
+              onSelectMap={handleSelectMap}
+            />
+          </div>
+        );
+      case 'category':
+        return (
+          <div onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div className="flex-1">
+                <h2 className="text-lg font-bold text-gray-900">필터</h2>
+              </div>
+              <button
+                className="px-3 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md"
+                onClick={e => {
+                  e.stopPropagation();
+                  backToList();
+                }}
+                aria-label="이전 화면으로 돌아가기"
+              >
+                뒤로
+              </button>
+            </div>
+            <CategorySelectContent
+              selectedCategory={selectedCategory}
+              onCategorySelect={selectCategoryAndNavigate}
+            />
+          </div>
+        );
+      case 'brand':
+        return (
+          <div onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div className="flex-1">
+                <h2 className="text-lg font-bold text-gray-900">필터</h2>
+              </div>
+              <button
+                className="px-3 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md"
+                onClick={e => {
+                  e.stopPropagation();
+                  backToList();
+                }}
+                aria-label="이전 화면으로 돌아가기"
+              >
+                뒤로
+              </button>
+            </div>
+            <BrandSelectContent
+              categoryKey={selectedCategory}
+              categoryDisplayName={selectedCategory}
+              brands={[]} // TODO: 브랜드 데이터 구현 필요
+              selectedBrand={selectedBrand}
+              onBrandSelect={selectBrandAndReturn}
+              onBack={backToList}
+            />
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
 
-  const bottomSheetSteps = [
-    {
-      key: 'list',
-      title: '주변 제휴 매장',
-      subtitle:
-        selectedCategory || selectedBrand
-          ? `${selectedCategory}${selectedBrand ? ' > ' + selectedBrand : ''}`
-          : undefined,
-      showFilterButton: true,
-      onFilterClick: showFilter,
-      content: (
-        <StoreListContent
-          stores={stores}
-          onFilterClick={showFilter}
-          onStoreClick={handleStoreSelect}
-        />
-      ),
-    },
-    {
-      key: 'category',
-      title: '필터',
-      showBackButton: true,
-      content: (
-        <CategorySelectContent
-          selectedCategory={selectedCategory}
-          onCategorySelect={selectCategoryAndNavigate}
-        />
-      ),
-    },
-    {
-      key: 'brand',
-      title: '필터',
-      showBackButton: true,
-      content: (
-        <BrandSelectContent
-          categoryKey={selectedCategory}
-          categoryDisplayName={selectedCategory}
-          brands={[]} // TODO: 브랜드 데이터 구현 필요
-          selectedBrand={selectedBrand}
-          onBrandSelect={selectBrandAndReturn}
-          onBack={backToList}
-        />
-      ),
-    },
-  ];
-
-  return (
-    <PersistentBottomSheet
-      steps={bottomSheetSteps}
-      currentStepKey={currentBottomSheetStep}
-      onStepChange={step =>
-        setBottomSheetStep(step as 'list' | 'category' | 'brand')
-      }
-      minHeight={80}
-      maxHeight={500}
-      defaultExpanded={true}
-      bottomNavHeight={30}
-    />
-  );
+  return <MapDragBottomSheet>{getCurrentStepContent()}</MapDragBottomSheet>;
 };

--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { MyMapList } from '@mymap/components/mymap-list';
 
 import { useMapData } from '../hooks/useMapData';
 import { useMapInteraction } from '../hooks/useMapInteraction';
@@ -21,6 +21,15 @@ export const BottomSheetContainer: React.FC = () => {
     backToList,
     setBottomSheetStep,
   } = useMapUI();
+
+  const handleCreateNewMap = () => {
+    // 추후 새 지도 추가하는 곳으로 이동 구현하기
+  };
+
+  const handleSelectMap = (id: number) => {
+    console.log(`지도 선택됨: ${id}`);
+    // 선택된 지도 상세 보기 또는 이동 처리
+  };
 
   const bottomSheetSteps = [
     {
@@ -48,7 +57,11 @@ export const BottomSheetContainer: React.FC = () => {
       showBackButton: true,
       content: (
         <div>
-          바텀시트 본문에 렌더링될 컴포넌트: 기본 mymap 화면을 구현하면된다
+          <MyMapList
+            favoriteLabel="즐겨찾기"
+            onCreateNewMap={handleCreateNewMap}
+            onSelectMap={handleSelectMap}
+          />
         </div>
       ),
     },

--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+
 import { useMapData } from '../hooks/useMapData';
-import { useMapUI } from '../hooks/useMapUI';
 import { useMapInteraction } from '../hooks/useMapInteraction';
+import { useMapUI } from '../hooks/useMapUI';
 import { PersistentBottomSheet } from './layout/PersistentBottomSheet';
 import StoreListContent from './layout/StoreListContent';
-import CategorySelectContent from './layout/steps/CategorySelectContent';
 import BrandSelectContent from './layout/steps/BrandSelectContent';
+import CategorySelectContent from './layout/steps/CategorySelectContent';
 
 export const BottomSheetContainer: React.FC = () => {
   const { stores } = useMapData();
@@ -31,12 +32,24 @@ export const BottomSheetContainer: React.FC = () => {
           : undefined,
       showFilterButton: true,
       onFilterClick: showFilter,
+      showMymapButton: true,
+      onMymapClick: () => setBottomSheetStep('mymap'),
       content: (
         <StoreListContent
           stores={stores}
           onFilterClick={showFilter}
           onStoreClick={handleStoreSelect}
         />
+      ),
+    },
+    {
+      key: 'mymap',
+      title: 'My Map',
+      showBackButton: true,
+      content: (
+        <div>
+          바텀시트 본문에 렌더링될 컴포넌트: 기본 mymap 화면을 구현하면된다
+        </div>
       ),
     },
     {
@@ -72,7 +85,7 @@ export const BottomSheetContainer: React.FC = () => {
       steps={bottomSheetSteps}
       currentStepKey={currentBottomSheetStep}
       onStepChange={step =>
-        setBottomSheetStep(step as 'list' | 'category' | 'brand')
+        setBottomSheetStep(step as 'list' | 'category' | 'brand' | 'mymap')
       }
       minHeight={80}
       maxHeight={500}

--- a/src/features/kakao-map/components/layout/PersistentBottomSheet.tsx
+++ b/src/features/kakao-map/components/layout/PersistentBottomSheet.tsx
@@ -11,6 +11,8 @@ interface Step {
   showBackButton?: boolean;
   showFilterButton?: boolean;
   onFilterClick?: () => void;
+  showMymapButton?: boolean;
+  onMymapClick?: () => void;
 }
 interface PersistentBottomSheetProps {
   /** 바텀시트에 표시할 스텝들의 배열 */
@@ -123,24 +125,39 @@ export const PersistentBottomSheet: React.FC<PersistentBottomSheetProps> = ({
               )}
             </div>
 
-            <div className="flex items-center gap-2">
-              {/* 필터 버튼 */}
-              {currentStep.showFilterButton && currentStep.onFilterClick && (
-                <button
-                  className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 border border-gray-200 hover:border-blue-300 shadow-sm hover:shadow-md"
-                  onClick={currentStep.onFilterClick}
-                  aria-label="필터 설정"
-                >
-                  <FaFilter className="w-3.5 h-3.5" />
-                  <span>필터</span>
-                </button>
-              )}
+            <div className="flex flex-row gap-2">
+              {/* MyMap 버튼 추가 */}
+              <div className="flex items-center gap-2">
+                {currentStep.showMymapButton && currentStep.onMymapClick && (
+                  <button
+                    className="flex items-center gap-1.5 px-3 py-2 text-sm font-bold text-black hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 border border-light-gray shadow-sm hover:shadow-md"
+                    onClick={currentStep.onMymapClick}
+                    aria-label="MyMap으로 이동"
+                  >
+                    <span>My Map</span>
+                  </button>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                {/* 필터 버튼 */}
+                {currentStep.showFilterButton && currentStep.onFilterClick && (
+                  <button
+                    className="flex items-center gap-1.5 px-3 py-2 text-sm font-bold text-black hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 border border-light-gray shadow-sm hover:shadow-md"
+                    onClick={currentStep.onFilterClick}
+                    aria-label="필터 설정"
+                  >
+                    <FaFilter className="w-3.5 h-3.5" />
+                    <span>필터</span>
+                  </button>
+                )}
+              </div>
 
               {/* 뒤로 가기 버튼 */}
               {currentStep.showBackButton &&
                 currentStepKey !== steps[0]?.key && (
                   <button
-                    className="px-3 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md"
+                    className="px-3 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 border border-gray-200 hover:border-gray-300 shadow-sm hover:shadow-md"
                     onClick={goBackToFirstStep}
                     aria-label="이전 화면으로 돌아가기"
                   >

--- a/src/features/kakao-map/context/MapUIContext.tsx
+++ b/src/features/kakao-map/context/MapUIContext.tsx
@@ -15,7 +15,7 @@ interface MapUIState {
   isSearchFocused: boolean;
 
   // 바텀시트 네비게이션 상태
-  currentBottomSheetStep: 'list' | 'category' | 'brand';
+  currentBottomSheetStep: 'list' | 'category' | 'brand' | 'mymap';
   isBottomSheetExpanded: boolean;
 
   // 필터 UI 상태
@@ -43,7 +43,7 @@ type MapUIAction =
   | { type: 'CLEAR_SEARCH' }
 
   // 바텀시트 관련 액션
-  | { type: 'SET_BOTTOM_SHEET_STEP'; payload: 'list' | 'category' | 'brand' }
+  | { type: 'SET_BOTTOM_SHEET_STEP'; payload: 'list' | 'category' | 'brand' | 'mymap' }
   | { type: 'SET_BOTTOM_SHEET_EXPANDED'; payload: boolean }
   | { type: 'TOGGLE_BOTTOM_SHEET' }
 
@@ -140,7 +140,7 @@ interface MapUIContextValue {
     clearSearch: () => void;
 
     // 바텀시트 관련 액션
-    setBottomSheetStep: (step: 'list' | 'category' | 'brand') => void;
+    setBottomSheetStep: (step: 'list' | 'category' | 'brand' | 'mymap') => void;
     setBottomSheetExpanded: (expanded: boolean) => void;
     toggleBottomSheet: () => void;
 
@@ -210,7 +210,7 @@ export const MapUIProvider: React.FC<{ children: React.ReactNode }> = ({
     }, []),
 
     // 바텀시트 관련 액션
-    setBottomSheetStep: useCallback((step: 'list' | 'category' | 'brand') => {
+    setBottomSheetStep: useCallback((step: 'list' | 'category' | 'brand' | 'mymap') => {
       dispatch({ type: 'SET_BOTTOM_SHEET_STEP', payload: step });
     }, []),
 

--- a/src/features/kakao-map/hooks/useMapUI.ts
+++ b/src/features/kakao-map/hooks/useMapUI.ts
@@ -12,6 +12,15 @@ export const useMapUI = () => {
   // 복합 액션들: 여러 UI 상태를 조합한 복잡한 동작들
 
   /**
+   * mymap 화면으로 이동
+   * 바텀시트를 mymap으로 변경하고 확장
+   */
+  const showMymap = useCallback(() => {
+    actions.setBottomSheetStep('mymap');
+    actions.setBottomSheetExpanded(true);
+  }, [actions]);
+
+  /**
    * 필터 선택 화면으로 이동
    * 바텀시트를 카테고리 선택 단계로 변경하고 확장
    */
@@ -84,6 +93,7 @@ export const useMapUI = () => {
     resetAllUI: actions.resetAllUI,
 
     // 복합 액션들 (이 훅에서 정의한 것)
+    showMymap,
     showFilter,
     selectCategoryAndNavigate,
     selectBrandAndReturn,

--- a/src/features/mymap/api/endpoint.ts
+++ b/src/features/mymap/api/endpoint.ts
@@ -1,0 +1,22 @@
+const MYMAP = '/mymap';
+
+export const MYMAP_ENDPOINTS = {
+  MYMAP: {
+    ROOT: MYMAP,
+    LIST: `${MYMAP}/list`,
+    DELETE: (myMapListId: number) => `/mymap/${myMapListId}`,
+    DELETE_MSW: (myMapListId: number | string = ':myMapListId') =>
+      `/mymap/${myMapListId}`,
+    VIEW: (uuid: number) => `/mymap/${uuid}`,
+    VIEW_MSW: (uuid: number | string = ':uuid') => `/mymap/${uuid}`,
+    STATE: (store_id: number) => `/mymap/list/${store_id}`,
+    STATE_MSW: (store_id: number | string = ':store_id') =>
+      `/mymap/list/${store_id}`,
+    TOGGLE_STORE: (myMapListId: number, store_id: number) =>
+      `/mymap/${myMapListId}/store/${store_id}`,
+    TOGGLE_STORE_MSW: (
+      myMapListId: number | string = ':store_id',
+      store_id: number | string = ':store_id'
+    ) => `/mymap/${myMapListId}/store/${store_id}`,
+  },
+};

--- a/src/features/mymap/api/endpoint.ts
+++ b/src/features/mymap/api/endpoint.ts
@@ -15,7 +15,7 @@ export const MYMAP_ENDPOINTS = {
     TOGGLE_STORE: (myMapListId: number, store_id: number) =>
       `/mymap/${myMapListId}/store/${store_id}`,
     TOGGLE_STORE_MSW: (
-      myMapListId: number | string = ':store_id',
+      myMapListId: number | string = ':myMapListId',
       store_id: number | string = ':store_id'
     ) => `/mymap/${myMapListId}/store/${store_id}`,
   },

--- a/src/features/mymap/api/mockData.ts
+++ b/src/features/mymap/api/mockData.ts
@@ -1,0 +1,17 @@
+import type { MyMapListRes } from './types';
+
+/**
+ * 목데이터: mymap 목록 조회
+ */
+export const monkMyMapList: MyMapListRes[] = [
+  {
+    myMapListId: 3,
+    title: 'test1',
+    markerColor: 'RED',
+  },
+  {
+    myMapListId: 4,
+    title: 'test2',
+    markerColor: 'GREEN',
+  },
+];

--- a/src/features/mymap/api/mockData.ts
+++ b/src/features/mymap/api/mockData.ts
@@ -3,7 +3,7 @@ import type { MyMapListRes } from './types';
 /**
  * 목데이터: mymap 목록 조회
  */
-export const mockMyMapList: MyMapListRes[] = [
+export const MOCK_MYMAP_LIST: MyMapListRes[] = [
   {
     myMapListId: 3,
     title: 'test1',

--- a/src/features/mymap/api/mockData.ts
+++ b/src/features/mymap/api/mockData.ts
@@ -3,7 +3,7 @@ import type { MyMapListRes } from './types';
 /**
  * 목데이터: mymap 목록 조회
  */
-export const monkMyMapList: MyMapListRes[] = [
+export const mockMyMapList: MyMapListRes[] = [
   {
     myMapListId: 3,
     title: 'test1',

--- a/src/features/mymap/api/mymapApi.ts
+++ b/src/features/mymap/api/mymapApi.ts
@@ -1,0 +1,14 @@
+import { client } from '@/shared/client';
+import type { ApiResponse } from '@/shared/client/client.type';
+
+import { MYMAP_ENDPOINTS } from './endpoint';
+import type { MyMapListRes } from './types';
+
+// My Map 목록 조회 api
+export const getMyMapList = async (): Promise<MyMapListRes[]> => {
+  const res = await client.get<ApiResponse<MyMapListRes[]>>(
+    MYMAP_ENDPOINTS.MYMAP.ROOT
+  );
+
+  return res.data.data!;
+};

--- a/src/features/mymap/api/mymapApi.ts
+++ b/src/features/mymap/api/mymapApi.ts
@@ -10,5 +10,8 @@ export const getMyMapList = async (): Promise<MyMapListRes[]> => {
     MYMAP_ENDPOINTS.MYMAP.ROOT
   );
 
-  return res.data.data!;
+  if (!res.data.data) {
+    throw new Error('MyMap 목록 데이터를 불러올 수 없습니다');
+  }
+  return res.data.data;
 };

--- a/src/features/mymap/api/types.ts
+++ b/src/features/mymap/api/types.ts
@@ -1,0 +1,8 @@
+/**
+ * My Map 목록 조회 응답
+ */
+export interface MyMapListRes {
+  myMapListId: number;
+  title: string;
+  markerColor: string;
+}

--- a/src/features/mymap/components/mymap-list/ADDMyMapButton.tsx
+++ b/src/features/mymap/components/mymap-list/ADDMyMapButton.tsx
@@ -1,0 +1,20 @@
+import { FiPlusCircle } from 'react-icons/fi';
+
+interface ADDMyMapButtonProps {
+  onCreateNewMap: () => void;
+}
+
+const ADDMyMapButton: React.FC<ADDMyMapButtonProps> = ({ onCreateNewMap }) => {
+  return (
+    <div className="hover:bg-light-gray-hover cursor-pointer">
+      <button
+        onClick={onCreateNewMap}
+        className="flex items-center text-primary font-bold text-body1 py-2 "
+      >
+        <FiPlusCircle className="mr-2" /> 새 지도 만들기
+      </button>
+    </div>
+  );
+};
+
+export default ADDMyMapButton;

--- a/src/features/mymap/components/mymap-list/ADDMyMapButton.tsx
+++ b/src/features/mymap/components/mymap-list/ADDMyMapButton.tsx
@@ -6,14 +6,12 @@ interface ADDMyMapButtonProps {
 
 const ADDMyMapButton: React.FC<ADDMyMapButtonProps> = ({ onCreateNewMap }) => {
   return (
-    <div className="hover:bg-light-gray-hover cursor-pointer">
-      <button
-        onClick={onCreateNewMap}
-        className="flex items-center text-primary font-bold text-body1 py-2 "
-      >
-        <FiPlusCircle className="mr-2" /> 새 지도 만들기
-      </button>
-    </div>
+    <button
+      onClick={onCreateNewMap}
+      className="flex items-center text-primary font-bold text-body1 py-2 hover:bg-light-gray-hover cursor-pointer transition-colors"
+    >
+      <FiPlusCircle className="mr-2" /> 새 지도 만들기
+    </button>
   );
 };
 

--- a/src/features/mymap/components/mymap-list/MyMapList.tsx
+++ b/src/features/mymap/components/mymap-list/MyMapList.tsx
@@ -1,0 +1,56 @@
+import { ADDMyMapButton } from '@mymap/components/mymap-list';
+import { MYMAP_COLOR, type MarkerColor } from '@mymap/constants/mymapColor';
+import { useMyMapListQuery } from '@mymap/hooks/useMyMapListQuery';
+import { BsThreeDotsVertical } from 'react-icons/bs';
+import { MdStars } from 'react-icons/md';
+
+interface MapListProps {
+  favoriteLabel: string;
+  onCreateNewMap: () => void;
+  onSelectMap: (id: number) => void;
+}
+
+const MyMapList: React.FC<MapListProps> = ({
+  favoriteLabel,
+  onCreateNewMap,
+  onSelectMap,
+}) => {
+  const { data, isLoading, isError } = useMyMapListQuery();
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError || !data) return <div>에러 발생</div>;
+
+  return (
+    <div className="flex flex-col w-full max-w-md mx-auto p-4 divide-y divide-gray-200">
+      {/* 새 지도 만들기 */}
+      <ADDMyMapButton onCreateNewMap={onCreateNewMap} />
+
+
+      {/* 즐겨찾기 */}
+      {/* 즐겨찾기 누르면 마이페이지 즐겨찾기 수정으로 이동 */}
+      <div className="flex items-center py-3">
+        <MdStars className="w-5 h-5 text-primary mr-2" />
+        <span className="text-body2 font-semibold">
+          {favoriteLabel}
+        </span>
+      </div>
+
+      {/* map 리스트 */}
+      {data.map(map => (
+        <div
+          key={map.myMapListId}
+          className="flex items-center justify-between py-3 cursor-pointer hover:bg-light-gray-hover rounded"
+          onClick={() => onSelectMap(map.myMapListId)}
+        >
+          <div className="flex items-center">
+            <MdStars className={`w-5 h-5 ${MYMAP_COLOR[map.markerColor as MarkerColor]}`} />
+            <span className="ml-2 text-body2 font-semibold">{map.title}</span>
+          </div>
+          <BsThreeDotsVertical />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MyMapList;

--- a/src/features/mymap/components/mymap-list/MyMapList.tsx
+++ b/src/features/mymap/components/mymap-list/MyMapList.tsx
@@ -5,16 +5,11 @@ import { BsThreeDotsVertical } from 'react-icons/bs';
 import { MdStars } from 'react-icons/md';
 
 interface MapListProps {
-  favoriteLabel: string;
   onCreateNewMap: () => void;
   onSelectMap: (id: number) => void;
 }
 
-const MyMapList: React.FC<MapListProps> = ({
-  favoriteLabel,
-  onCreateNewMap,
-  onSelectMap,
-}) => {
+const MyMapList: React.FC<MapListProps> = ({ onCreateNewMap, onSelectMap }) => {
   const { data, isLoading, isError } = useMyMapListQuery();
 
   if (isLoading) return <div>로딩 중...</div>;
@@ -25,14 +20,11 @@ const MyMapList: React.FC<MapListProps> = ({
       {/* 새 지도 만들기 */}
       <ADDMyMapButton onCreateNewMap={onCreateNewMap} />
 
-
       {/* 즐겨찾기 */}
       {/* 즐겨찾기 누르면 마이페이지 즐겨찾기 수정으로 이동 */}
       <div className="flex items-center py-3">
         <MdStars className="w-5 h-5 text-primary mr-2" />
-        <span className="text-body2 font-semibold">
-          {favoriteLabel}
-        </span>
+        <span className="text-body2 font-semibold">즐겨찾기</span>
       </div>
 
       {/* map 리스트 */}
@@ -43,7 +35,9 @@ const MyMapList: React.FC<MapListProps> = ({
           onClick={() => onSelectMap(map.myMapListId)}
         >
           <div className="flex items-center">
-            <MdStars className={`w-5 h-5 ${MYMAP_COLOR[map.markerColor as MarkerColor] || MYMAP_COLOR.RED}}`} />
+            <MdStars
+              className={`w-5 h-5 ${MYMAP_COLOR[map.markerColor as MarkerColor] || MYMAP_COLOR.RED}`}
+            />
             <span className="ml-2 text-body2 font-semibold">{map.title}</span>
           </div>
           <BsThreeDotsVertical />

--- a/src/features/mymap/components/mymap-list/MyMapList.tsx
+++ b/src/features/mymap/components/mymap-list/MyMapList.tsx
@@ -43,7 +43,7 @@ const MyMapList: React.FC<MapListProps> = ({
           onClick={() => onSelectMap(map.myMapListId)}
         >
           <div className="flex items-center">
-            <MdStars className={`w-5 h-5 ${MYMAP_COLOR[map.markerColor as MarkerColor]}`} />
+            <MdStars className={`w-5 h-5 ${MYMAP_COLOR[map.markerColor as MarkerColor] || MYMAP_COLOR.RED}}`} />
             <span className="ml-2 text-body2 font-semibold">{map.title}</span>
           </div>
           <BsThreeDotsVertical />

--- a/src/features/mymap/components/mymap-list/index.ts
+++ b/src/features/mymap/components/mymap-list/index.ts
@@ -1,0 +1,2 @@
+export { default as ADDMyMapButton } from './ADDMyMapButton';
+export { default as MyMapList } from './MyMapList';

--- a/src/features/mymap/constants/mymapColor.ts
+++ b/src/features/mymap/constants/mymapColor.ts
@@ -1,9 +1,9 @@
 export type MarkerColor = 'RED' | 'ORANGE' | 'YELLOW' | 'GREEN' | 'PURPLE';
 
 export const MYMAP_COLOR: Record<MarkerColor, string> = {
-  RED: 'text-[color:var(--text-red)]',
-  ORANGE: 'text-[color:var(--text-orange)]',
-  YELLOW: 'text-[color:var(--text-yellow)]',
-  GREEN: 'text-[color:var(--text-green)]',
-  PURPLE: 'text-[color:var(--text-purple)]',
+  RED: 'text-red',
+  ORANGE: 'text-orange',
+  YELLOW: 'text-yellow',
+  GREEN: 'text-green',
+  PURPLE: 'text-purple',
 };

--- a/src/features/mymap/constants/mymapColor.ts
+++ b/src/features/mymap/constants/mymapColor.ts
@@ -1,0 +1,9 @@
+export type MarkerColor = 'RED' | 'ORANGE' | 'YELLOW' | 'GREEN' | 'PURPLE';
+
+export const MYMAP_COLOR: Record<MarkerColor, string> = {
+  RED: 'text-[color:var(--text-red)]',
+  ORANGE: 'text-[color:var(--text-orange)]',
+  YELLOW: 'text-[color:var(--text-yellow)]',
+  GREEN: 'text-[color:var(--text-green)]',
+  PURPLE: 'text-[color:var(--text-purple)]',
+};

--- a/src/features/mymap/hooks/useMyMapListQuery.ts
+++ b/src/features/mymap/hooks/useMyMapListQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyMapList } from "../api/mymapApi";
+import type { MyMapListRes } from "../api/types";
+
+export const useMyMapListQuery = () => {
+  return useQuery<MyMapListRes[]>({
+    queryKey: ['mymaplist'],
+    queryFn: getMyMapList,
+  });
+};

--- a/src/index.css
+++ b/src/index.css
@@ -274,7 +274,10 @@
   --text-tertiary: #d9d9d9;
   --text-secondary: #71717a;
   --text-gray: #b0b8c1;
-  --text-red: #dc2625;
+  --text-red: #FF3B30;
+  --text-orange:#FF9500;
+  --text-yellow: #FFCC00;
+  --text-green: #34C759;
   --text-white: #ffffff;
   --text-success: #2db745;
   --text-warning: #feb93f;

--- a/src/index.css
+++ b/src/index.css
@@ -274,10 +274,10 @@
   --text-tertiary: #d9d9d9;
   --text-secondary: #71717a;
   --text-gray: #b0b8c1;
-  --text-red: #FF3B30;
-  --text-orange:#FF9500;
-  --text-yellow: #FFCC00;
-  --text-green: #34C759;
+  --text-red: #ff3b30;
+  --text-orange: #ff9500;
+  --text-yellow: #ffcc00;
+  --text-green: #34c759;
   --text-white: #ffffff;
   --text-success: #2db745;
   --text-warning: #feb93f;
@@ -304,6 +304,15 @@
   }
   .text-red {
     color: var(--text-red);
+  }
+  .text-orange {
+    color: var(--text-orange);
+  }
+  .text-yellow {
+    color: var(--text-yellow);
+  }
+  .text-green {
+    color: var(--text-green);
   }
   .text-white {
     color: var(--text-white);

--- a/src/shared/msw/handlers/benefit.ts
+++ b/src/shared/msw/handlers/benefit.ts
@@ -1,5 +1,5 @@
 import { BENEFIT_ENDPOINTS } from '@benefit/api/endpoints';
-import { allBrands, mockBrandDetails } from '@benefit/api/mockData';
+import { mockAllBrands, mockBrandDetails } from '@benefit/api/mockData';
 import type { BenefitType, BrandListRes, StoreType } from '@benefit/api/types';
 import { http } from 'msw';
 
@@ -29,7 +29,7 @@ export const benefitHandlers = [
       const benefitType = url.searchParams.get('benefitType');
 
       // 초기 브랜드 리스트 전체 복사
-      let filtered = [...allBrands];
+      let filtered = [...mockAllBrands];
 
       // category 필터링
       if (category && category !== 'all') {

--- a/src/shared/msw/handlers/benefit.ts
+++ b/src/shared/msw/handlers/benefit.ts
@@ -1,5 +1,5 @@
 import { BENEFIT_ENDPOINTS } from '@benefit/api/endpoints';
-import { mockAllBrands, mockBrandDetails } from '@benefit/api/mockData';
+import { MOCK_ALL_BRANDS, MOCK_BRAND_DETAILS } from '@benefit/api/mockData';
 import type { BenefitType, BrandListRes, StoreType } from '@benefit/api/types';
 import { http } from 'msw';
 
@@ -29,7 +29,7 @@ export const benefitHandlers = [
       const benefitType = url.searchParams.get('benefitType');
 
       // 초기 브랜드 리스트 전체 복사
-      let filtered = [...mockAllBrands];
+      let filtered = [...MOCK_ALL_BRANDS];
 
       // category 필터링
       if (category && category !== 'all') {
@@ -81,7 +81,7 @@ export const benefitHandlers = [
   http.get(BENEFIT_ENDPOINTS.BENEFIT.DETAIL_MSW(), ({ params }) => {
     const { brandId } = params;
 
-    const brand = mockBrandDetails.find(b => b.brandId === Number(brandId));
+    const brand = MOCK_BRAND_DETAILS.find(b => b.brandId === Number(brandId));
     const shouldFail = false;
     if (shouldFail) {
       //임시 에러메시지

--- a/src/shared/msw/handlers/index.ts
+++ b/src/shared/msw/handlers/index.ts
@@ -1,6 +1,7 @@
 import { benefitHandlers } from './benefit';
 import { homeHandlers } from './home';
 import { mapHandlers } from './map';
+import { mymapHandlers } from './mymap';
 import { userHandlers } from './user';
 
 export const handlers = [
@@ -8,4 +9,5 @@ export const handlers = [
   ...mapHandlers,
   ...homeHandlers,
   ...benefitHandlers,
+  ...mymapHandlers,
 ];

--- a/src/shared/msw/handlers/index.ts
+++ b/src/shared/msw/handlers/index.ts
@@ -2,14 +2,14 @@ import { benefitHandlers } from './benefit';
 import { homeHandlers } from './home';
 import { mapHandlers } from './map';
 import { mymapHandlers } from './mymap';
-import { userHandlers } from './user';
 import { mypageHandlers } from './mypage';
+import { userHandlers } from './user';
 
 export const handlers = [
   ...userHandlers,
   ...mapHandlers,
   ...homeHandlers,
   ...benefitHandlers,
-  ...mypageHandlers
+  ...mypageHandlers,
   ...mymapHandlers,
 ];

--- a/src/shared/msw/handlers/mymap.ts
+++ b/src/shared/msw/handlers/mymap.ts
@@ -1,5 +1,5 @@
 import { MYMAP_ENDPOINTS } from '@/features/mymap/api/endpoint';
-import { monkMyMapList } from '@/features/mymap/api/mockData';
+import { mockMyMapList } from '@/features/mymap/api/mockData';
 import { http } from 'msw';
 
 import { createErrorResponse } from '@/shared/utils/createErrorResponse';
@@ -14,6 +14,6 @@ export const mymapHandlers = [
       //실패 시
       return createErrorResponse('에러처리.', 400);
     }
-    return createResponse(monkMyMapList, '성공');
+    return createResponse(mockMyMapList, '성공');
   }),
 ];

--- a/src/shared/msw/handlers/mymap.ts
+++ b/src/shared/msw/handlers/mymap.ts
@@ -1,0 +1,19 @@
+import { MYMAP_ENDPOINTS } from '@/features/mymap/api/endpoint';
+import { monkMyMapList } from '@/features/mymap/api/mockData';
+import { http } from 'msw';
+
+import { createErrorResponse } from '@/shared/utils/createErrorResponse';
+import { createResponse } from '@/shared/utils/createResponse';
+
+export const mymapHandlers = [
+  // My Map 목록 조회 MSW 핸들러
+  http.get(MYMAP_ENDPOINTS.MYMAP.ROOT, () => {
+    const shouldFail = false;
+
+    if (shouldFail) {
+      //실패 시
+      return createErrorResponse('에러처리.', 400);
+    }
+    return createResponse(monkMyMapList, '성공');
+  }),
+];

--- a/src/shared/msw/handlers/mymap.ts
+++ b/src/shared/msw/handlers/mymap.ts
@@ -1,5 +1,5 @@
 import { MYMAP_ENDPOINTS } from '@/features/mymap/api/endpoint';
-import { mockMyMapList } from '@/features/mymap/api/mockData';
+import { MOCK_MYMAP_LIST } from '@/features/mymap/api/mockData';
 import { http } from 'msw';
 
 import { createErrorResponse } from '@/shared/utils/createErrorResponse';
@@ -14,6 +14,6 @@ export const mymapHandlers = [
       //실패 시
       return createErrorResponse('에러처리.', 400);
     }
-    return createResponse(mockMyMapList, '성공');
+    return createResponse(MOCK_MYMAP_LIST, '성공');
   }),
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "@extra-info/*": ["./src/features/extra-info/*"],
       "@benefit/*": ["./src/features/benefit/*"],
       "@mypage/*": ["./src/features/mypage/*"],
+      "@mymap/*": ["./src/features/mymap/*"],
       "@paths": ["./src/routes/path.ts"],
       "@/*": ["./src/*"]
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,11 @@
 /// <reference types="vitest/config" />
 // https://vite.dev/config/
-import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
-import tailwindcss from "@tailwindcss/vite";
-import react from "@vitejs/plugin-react";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
-
-
-
-
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
 
 // ES Module 환경에서 __dirname 대신 사용
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -26,6 +22,7 @@ export default defineConfig({
       '@paths': path.resolve(__dirname, 'src/routes/path.ts'),
       '@user': path.resolve(__dirname, 'src/features/user'),
       '@mypage': path.resolve(__dirname, 'src/features/mypage'),
+      '@mymap': path.resolve(__dirname, 'src/features/mymap'),
       '@kakao-map': path.resolve(__dirname, 'src/features/kakao-map'),
     },
   },


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
1. 바텀시트에 MyMap 버튼 및 화면 전환 기능 추가
- BottomSheetContainer.tsx: mymap을 바텀시트 스텝에 추가하고 버튼 클릭 시 해당 단계로 전환되도록 설정
- PersistentBottomSheet.tsx: showMymapButton 옵션에 따라 헤더에 "My Map" 버튼을 조건부 렌더링
- useMapUI.ts: 바텀시트를 MyMap 단계로 전환하는 showMymap 복합 액션 함수 추가
- MapUIContext.tsx: mymap 단계를 바텀시트 상태 관리 로직에 통합하여 사용 가능하게 구현

3. 즐겨찾기 + My Map 목록 조회
- endpoint
- 타입 정의
- 목데이터
- MSW 핸들러
- api 함수
- 쿼리 훅

4. MyMapList UI 및 바텀시트 연동 기능 구현
- @mymap 추가
- BottomSheetContainer에 MyMap MyMapList를 통합하고 스텝 전환 로직 연결
- ADDMyMapButton 컴포넌트 생성 및 버튼 클릭 시 새 지도 생성 핸들러 호출 처리
- MyMapList 컴포넌트 구현: useMyMapListQuery로 사용자 지도 목록 조회 및 선택 시 콜백 실행
- MYMAP_COLOR 색상 타입 기반 클래스 매핑으로 마커 색상에 따른 UI 스타일 적용

# 현재 UI 캡처

|UI 제목1|
|:--:|
|![mymap 목록 조회](https://github.com/user-attachments/assets/7810337c-a8b6-4127-8449-67d64c9f50b3)|


## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * "마이 맵" 목록 확인, 새 지도 생성, 지도 선택 기능이 하단 시트에 추가되었습니다.
  * "마이 맵" 목록 조회 API와 목데이터, 관련 컴포넌트 및 커스텀 훅이 도입되었습니다.
  * "마이 맵" 관련 컬러 타입과 스타일 유틸리티가 추가되었습니다.

* **버그 수정**
  * 브랜드 목데이터의 명칭이 대문자 및 접두어 MOCK_ 형태로 변경되어 일관성이 향상되었습니다.

* **스타일**
  * 텍스트 컬러 변수와 유틸리티 클래스가 확장되어 다양한 색상 지원이 강화되었습니다.

* **문서화/환경설정**
  * "마이 맵" 관련 경로 별칭이 TypeScript 및 Vite 설정에 추가되었습니다.

* **테스트**
  * "마이 맵" 기능용 목서버 핸들러가 새로 추가되어 테스트 환경이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->