### PR TITLE
[FEAT][UHYU-235] 지도 핵심 - 일정 거리 이상 지도 이동 시 재검색 버튼 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ src/features/{feature-name}/
   VITE_USE_MOCK_DATA=true
 - 실제 API 연동
   VITE_USE_MOCK_DATA=false
+- 지도 재검색 거리 설정 (미터 단위)
+  VITE_SEARCH_DISTANCE_THRESHOLD=5000  # 기본값: 5km
 
 ### **핵심 전략 요약**
 

--- a/src/features/kakao-map/components/ManualSearchButton.tsx
+++ b/src/features/kakao-map/components/ManualSearchButton.tsx
@@ -1,5 +1,6 @@
-import { RefreshCw } from 'lucide-react';
 import React from 'react';
+
+import { RefreshCw } from 'lucide-react';
 
 interface ManualSearchButtonProps {
   /** 버튼 표시 여부 */
@@ -35,7 +36,7 @@ export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
   return (
     <div
       className={`
-        fixed top-20 left-1/2 -translate-x-1/2 z-20
+        fixed top-32 left-1/2 -translate-x-1/2 z-20
         transition-all duration-300 ease-out
         ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'}
         ${className}
@@ -51,25 +52,26 @@ export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
           rounded-full shadow-lg hover:shadow-xl
           transition-all duration-200 
           font-medium text-sm
-          ${loading 
-            ? 'cursor-not-allowed opacity-75' 
-            : 'hover:bg-gray-50 active:scale-95 cursor-pointer'
+          ${
+            loading
+              ? 'cursor-not-allowed opacity-75'
+              : 'hover:bg-gray-50 active:scale-95 cursor-pointer'
           }
           backdrop-blur-sm
         `}
         aria-label="이 지역에서 재검색"
       >
-        <RefreshCw 
-          size={16} 
+        <RefreshCw
+          size={16}
           className={`
             ${loading ? 'animate-spin' : ''}
             text-blue-600
-          `} 
+          `}
         />
         <span className="whitespace-nowrap">
           {loading ? '검색 중...' : '이 지역에서 재검색'}
         </span>
-        
+
         {/* 이동 거리 표시 (개발 모드에서만) */}
         {import.meta.env.MODE === 'development' && distance && (
           <span className="text-xs text-gray-500 ml-1">
@@ -77,7 +79,7 @@ export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
           </span>
         )}
       </button>
-      
+
       {/* 버튼 아래 작은 화살표 (지도를 가리키는 효과) */}
       <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1">
         <div className="w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-200 drop-shadow-sm" />
@@ -94,7 +96,6 @@ export const MobileManualSearchButton: React.FC<ManualSearchButtonProps> = ({
   visible,
   loading = false,
   onClick,
-  distance,
   className = '',
 }) => {
   if (!visible) return null;
@@ -107,7 +108,7 @@ export const MobileManualSearchButton: React.FC<ManualSearchButtonProps> = ({
   return (
     <div
       className={`
-        fixed top-16 left-1/2 -translate-x-1/2 z-20
+        fixed top-28 left-1/2 -translate-x-1/2 z-20
         transition-all duration-300 ease-out
         ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'}
         ${className}
@@ -123,20 +124,21 @@ export const MobileManualSearchButton: React.FC<ManualSearchButtonProps> = ({
           rounded-full shadow-lg
           transition-all duration-200 
           font-medium text-xs
-          ${loading 
-            ? 'cursor-not-allowed opacity-75' 
-            : 'hover:bg-gray-50 active:scale-95 cursor-pointer'
+          ${
+            loading
+              ? 'cursor-not-allowed opacity-75'
+              : 'hover:bg-gray-50 active:scale-95 cursor-pointer'
           }
           backdrop-blur-sm
         `}
         aria-label="재검색"
       >
-        <RefreshCw 
-          size={14} 
+        <RefreshCw
+          size={14}
           className={`
             ${loading ? 'animate-spin' : ''}
             text-blue-600
-          `} 
+          `}
         />
         <span className="whitespace-nowrap">
           {loading ? '검색중' : '재검색'}
@@ -150,14 +152,16 @@ export const MobileManualSearchButton: React.FC<ManualSearchButtonProps> = ({
  * 반응형 재검색 버튼
  * 화면 크기에 따라 적절한 버전을 자동 선택
  */
-export const ResponsiveManualSearchButton: React.FC<ManualSearchButtonProps> = (props) => {
+export const ResponsiveManualSearchButton: React.FC<
+  ManualSearchButtonProps
+> = props => {
   return (
     <>
       {/* 데스크톱/태블릿 버전 */}
       <div className="hidden sm:block">
         <ManualSearchButton {...props} />
       </div>
-      
+
       {/* 모바일 버전 */}
       <div className="block sm:hidden">
         <MobileManualSearchButton {...props} />

--- a/src/features/kakao-map/components/ManualSearchButton.tsx
+++ b/src/features/kakao-map/components/ManualSearchButton.tsx
@@ -1,0 +1,169 @@
+import { RefreshCw } from 'lucide-react';
+import React from 'react';
+
+interface ManualSearchButtonProps {
+  /** 버튼 표시 여부 */
+  visible: boolean;
+  /** 로딩 상태 */
+  loading?: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+  /** 마지막 검색 위치로부터의 거리 (미터) */
+  distance?: number;
+  /** 추가 CSS 클래스 */
+  className?: string;
+}
+
+/**
+ * 거리 기반 재검색 버튼
+ * 지도 위에 floating 형태로 표시되며, 기준 위치에서 일정 거리 이동 시 나타남
+ */
+export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
+  visible,
+  loading = false,
+  onClick,
+  distance,
+  className = '',
+}) => {
+  if (!visible) return null;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 지도 클릭 이벤트와 분리
+    onClick();
+  };
+
+  return (
+    <div
+      className={`
+        fixed top-20 left-1/2 -translate-x-1/2 z-20
+        transition-all duration-300 ease-out
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'}
+        ${className}
+      `}
+    >
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className={`
+          flex items-center gap-2 px-4 py-2.5
+          bg-white text-gray-800 
+          border border-gray-200 
+          rounded-full shadow-lg hover:shadow-xl
+          transition-all duration-200 
+          font-medium text-sm
+          ${loading 
+            ? 'cursor-not-allowed opacity-75' 
+            : 'hover:bg-gray-50 active:scale-95 cursor-pointer'
+          }
+          backdrop-blur-sm
+        `}
+        aria-label="이 지역에서 재검색"
+      >
+        <RefreshCw 
+          size={16} 
+          className={`
+            ${loading ? 'animate-spin' : ''}
+            text-blue-600
+          `} 
+        />
+        <span className="whitespace-nowrap">
+          {loading ? '검색 중...' : '이 지역에서 재검색'}
+        </span>
+        
+        {/* 이동 거리 표시 (개발 모드에서만) */}
+        {import.meta.env.MODE === 'development' && distance && (
+          <span className="text-xs text-gray-500 ml-1">
+            ({Math.round(distance)}m)
+          </span>
+        )}
+      </button>
+      
+      {/* 버튼 아래 작은 화살표 (지도를 가리키는 효과) */}
+      <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1">
+        <div className="w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-200 drop-shadow-sm" />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * 모바일 최적화된 재검색 버튼
+ * 작은 화면에서 더 적절한 크기와 위치
+ */
+export const MobileManualSearchButton: React.FC<ManualSearchButtonProps> = ({
+  visible,
+  loading = false,
+  onClick,
+  distance,
+  className = '',
+}) => {
+  if (!visible) return null;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick();
+  };
+
+  return (
+    <div
+      className={`
+        fixed top-16 left-1/2 -translate-x-1/2 z-20
+        transition-all duration-300 ease-out
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'}
+        ${className}
+      `}
+    >
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className={`
+          flex items-center gap-1.5 px-3 py-2
+          bg-white text-gray-800 
+          border border-gray-200 
+          rounded-full shadow-lg
+          transition-all duration-200 
+          font-medium text-xs
+          ${loading 
+            ? 'cursor-not-allowed opacity-75' 
+            : 'hover:bg-gray-50 active:scale-95 cursor-pointer'
+          }
+          backdrop-blur-sm
+        `}
+        aria-label="재검색"
+      >
+        <RefreshCw 
+          size={14} 
+          className={`
+            ${loading ? 'animate-spin' : ''}
+            text-blue-600
+          `} 
+        />
+        <span className="whitespace-nowrap">
+          {loading ? '검색중' : '재검색'}
+        </span>
+      </button>
+    </div>
+  );
+};
+
+/**
+ * 반응형 재검색 버튼
+ * 화면 크기에 따라 적절한 버전을 자동 선택
+ */
+export const ResponsiveManualSearchButton: React.FC<ManualSearchButtonProps> = (props) => {
+  return (
+    <>
+      {/* 데스크톱/태블릿 버전 */}
+      <div className="hidden sm:block">
+        <ManualSearchButton {...props} />
+      </div>
+      
+      {/* 모바일 버전 */}
+      <div className="block sm:hidden">
+        <MobileManualSearchButton {...props} />
+      </div>
+    </>
+  );
+};
+
+export default ResponsiveManualSearchButton;

--- a/src/features/kakao-map/components/MapContainer.tsx
+++ b/src/features/kakao-map/components/MapContainer.tsx
@@ -3,8 +3,12 @@ import { useMapData } from '../hooks/useMapData';
 import { useMapInteraction } from '../hooks/useMapInteraction';
 import MapWithMarkers from './marker/MapWithMarkers';
 
-export const MapContainer: React.FC = () => {
-  const { stores, mapCenter, userLocation } = useMapData();
+interface MapContainerProps {
+  // Props removed - distance-based search is now always enabled
+}
+
+export const MapContainer: React.FC<MapContainerProps> = () => {
+  const { stores, mapCenter, userLocation, loading } = useMapData();
   const { handleMapCenterChange, handleMarkerClick } = useMapInteraction();
 
   return (
@@ -14,6 +18,7 @@ export const MapContainer: React.FC = () => {
       currentLocation={userLocation}
       onStoreClick={handleMarkerClick}
       onCenterChange={handleMapCenterChange}
+      isSearching={loading.stores}
     />
   );
 };

--- a/src/features/kakao-map/components/MapContainer.tsx
+++ b/src/features/kakao-map/components/MapContainer.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
+
 import { useMapData } from '../hooks/useMapData';
 import { useMapInteraction } from '../hooks/useMapInteraction';
 import MapWithMarkers from './marker/MapWithMarkers';
 
-interface MapContainerProps {
-  // Props removed - distance-based search is now always enabled
-}
-
-export const MapContainer: React.FC<MapContainerProps> = () => {
+export const MapContainer: React.FC = () => {
   const { stores, mapCenter, userLocation, loading } = useMapData();
   const { handleMapCenterChange, handleMarkerClick } = useMapInteraction();
 

--- a/src/features/kakao-map/components/SearchModeToggle.tsx
+++ b/src/features/kakao-map/components/SearchModeToggle.tsx
@@ -1,0 +1,104 @@
+import { Search, SearchX } from 'lucide-react';
+import React from 'react';
+
+interface SearchModeToggleProps {
+  /** 수동 검색 모드 활성화 여부 */
+  isManualMode: boolean;
+  /** 모드 변경 핸들러 */
+  onToggle: (isManual: boolean) => void;
+  /** 추가 CSS 클래스 */
+  className?: string;
+}
+
+/**
+ * 자동/수동 검색 모드 토글 컴포넌트
+ * 사용자가 검색 방식을 선택할 수 있도록 함
+ */
+export const SearchModeToggle: React.FC<SearchModeToggleProps> = ({
+  isManualMode,
+  onToggle,
+  className = '',
+}) => {
+  const handleToggle = () => {
+    onToggle(!isManualMode);
+  };
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <span className="text-sm text-gray-600 font-medium">검색 모드:</span>
+      
+      <button
+        onClick={handleToggle}
+        className={`
+          flex items-center gap-2 px-3 py-1.5 rounded-full
+          transition-all duration-200 text-sm font-medium
+          ${isManualMode
+            ? 'bg-orange-100 text-orange-700 border border-orange-200'
+            : 'bg-blue-100 text-blue-700 border border-blue-200'
+          }
+          hover:shadow-sm active:scale-95
+        `}
+        aria-label={`${isManualMode ? '수동' : '자동'} 검색 모드 (클릭하여 변경)`}
+      >
+        {isManualMode ? (
+          <>
+            <SearchX size={14} />
+            <span>수동</span>
+          </>
+        ) : (
+          <>
+            <Search size={14} />
+            <span>자동</span>
+          </>
+        )}
+      </button>
+      
+      <span className="text-xs text-gray-500">
+        {isManualMode ? '이동 시 버튼으로 검색' : '이동 시 자동 검색'}
+      </span>
+    </div>
+  );
+};
+
+/**
+ * 간단한 토글 스위치 버전
+ */
+export const SearchModeSwitch: React.FC<SearchModeToggleProps> = ({
+  isManualMode,
+  onToggle,
+  className = '',
+}) => {
+  const handleToggle = () => {
+    onToggle(!isManualMode);
+  };
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <span className="text-sm text-gray-700">자동 검색</span>
+      
+      <button
+        onClick={handleToggle}
+        className={`
+          relative inline-flex h-6 w-11 items-center rounded-full
+          transition-colors duration-200 ease-in-out focus:outline-none
+          ${isManualMode ? 'bg-orange-400' : 'bg-blue-400'}
+        `}
+        role="switch"
+        aria-checked={!isManualMode}
+        aria-label="자동 검색 모드 토글"
+      >
+        <span
+          className={`
+            inline-block h-4 w-4 transform rounded-full bg-white
+            transition-transform duration-200 ease-in-out
+            ${isManualMode ? 'translate-x-1' : 'translate-x-6'}
+          `}
+        />
+      </button>
+      
+      <span className="text-sm text-gray-700">수동 검색</span>
+    </div>
+  );
+};
+
+export default SearchModeToggle;

--- a/src/features/kakao-map/hooks/useManualSearch.ts
+++ b/src/features/kakao-map/hooks/useManualSearch.ts
@@ -1,0 +1,190 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * 거리 기반 재검색 기능을 위한 상태 관리 훅
+ * 검색 위치에서 특정 거리 이상 이동 시 재검색 버튼 표시
+ */
+
+// 재검색 버튼이 표시되는 최소 이동 거리 (미터)
+const SHOW_BUTTON_DISTANCE = 200;
+
+export interface SearchState {
+  /** 재검색 버튼 표시 여부 */
+  showButton: boolean;
+  /** 마지막 검색 위치 */
+  lastSearchPosition: { lat: number; lng: number } | null;
+  /** 현재 위치에서 마지막 검색 위치까지의 거리 (미터) */
+  distanceFromLastSearch: number;
+}
+
+export interface SearchActions {
+  /** 지도 이동 시 호출 - 거리 계산 및 버튼 표시 여부 결정 */
+  handleMapMove: (newPosition: { lat: number; lng: number }) => void;
+  /** 재검색 버튼 클릭 시 호출 */
+  handleSearch: () => void;
+  /** 검색 실행 시 호출 - 기준 위치 업데이트 */
+  updateSearchPosition: (position: { lat: number; lng: number }) => void;
+  /** 상태 초기화 */
+  reset: () => void;
+}
+
+export const useDistanceBasedSearch = () => {
+  const [state, setState] = useState<SearchState>({
+    showButton: false,
+    lastSearchPosition: null,
+    distanceFromLastSearch: 0,
+  });
+
+  // 최신 검색 위치를 항상 참조하기 위한 ref
+  const lastSearchPositionRef = useRef<{ lat: number; lng: number } | null>(null);
+  
+  // 거리 계산 결과 캐싱을 위한 ref
+  const lastCalculatedDistance = useRef<{
+    from: { lat: number; lng: number };
+    to: { lat: number; lng: number };
+    distance: number;
+  } | null>(null);
+
+  /**
+   * 두 좌표 간의 거리 계산 (Haversine formula)
+   * 기존 MapWithMarkers의 로직과 동일하지만 캐싱 추가
+   */
+  const calculateDistance = useCallback(
+    (pos1: { lat: number; lng: number }, pos2: { lat: number; lng: number }) => {
+      // 캐싱된 결과가 있고 동일한 좌표라면 재사용
+      if (
+        lastCalculatedDistance.current &&
+        lastCalculatedDistance.current.from.lat === pos1.lat &&
+        lastCalculatedDistance.current.from.lng === pos1.lng &&
+        lastCalculatedDistance.current.to.lat === pos2.lat &&
+        lastCalculatedDistance.current.to.lng === pos2.lng
+      ) {
+        return lastCalculatedDistance.current.distance;
+      }
+
+      const R = 6371e3; // 지구 반지름 (미터)
+      const φ1 = (pos1.lat * Math.PI) / 180;
+      const φ2 = (pos2.lat * Math.PI) / 180;
+      const Δφ = ((pos2.lat - pos1.lat) * Math.PI) / 180;
+      const Δλ = ((pos2.lng - pos1.lng) * Math.PI) / 180;
+
+      const a =
+        Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+        Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      const distance = R * c;
+
+      // 결과 캐싱
+      lastCalculatedDistance.current = {
+        from: pos1,
+        to: pos2,
+        distance,
+      };
+
+      return distance;
+    },
+    []
+  );
+
+  /**
+   * 지도 이동 시 거리 계산 및 버튼 표시 여부 결정
+   */
+  const handleMapMove = useCallback(
+    (newPosition: { lat: number; lng: number }) => {
+      if (!lastSearchPositionRef.current) {
+        // 첫 번째 이동이면 현재 위치를 기준 위치로 설정
+        lastSearchPositionRef.current = newPosition;
+        setState(prev => ({
+          ...prev,
+          lastSearchPosition: newPosition,
+          distanceFromLastSearch: 0,
+          showButton: false,
+        }));
+        return;
+      }
+
+      const distance = calculateDistance(lastSearchPositionRef.current, newPosition);
+
+      setState(prev => ({
+        ...prev,
+        distanceFromLastSearch: distance,
+        showButton: distance >= SHOW_BUTTON_DISTANCE,
+      }));
+
+      if (import.meta.env.MODE === 'development') {
+        console.log(`🔍 Distance Search: 이동 거리 ${Math.round(distance)}m, 버튼 표시: ${distance >= SHOW_BUTTON_DISTANCE}`);
+      }
+    },
+    [calculateDistance]
+  );
+
+  /**
+   * 재검색 버튼 클릭 시 실행
+   * 실제 검색은 호출하는 컴포넌트에서 처리
+   */
+  const handleSearch = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      showButton: false,
+      distanceFromLastSearch: 0,
+    }));
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔍 Distance Search: 재검색 실행');
+    }
+  }, []);
+
+  /**
+   * 검색 실행 시 기준 위치 업데이트
+   */
+  const updateSearchPosition = useCallback((position: { lat: number; lng: number }) => {
+    lastSearchPositionRef.current = position;
+    setState(prev => ({
+      ...prev,
+      lastSearchPosition: position,
+      showButton: false,
+      distanceFromLastSearch: 0,
+    }));
+
+    // 캐시 초기화
+    lastCalculatedDistance.current = null;
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔍 Distance Search: 검색 위치 업데이트', position);
+    }
+  }, []);
+
+  /**
+   * 상태 완전 초기화
+   */
+  const reset = useCallback(() => {
+    lastSearchPositionRef.current = null;
+    setState({
+      showButton: false,
+      lastSearchPosition: null,
+      distanceFromLastSearch: 0,
+    });
+    lastCalculatedDistance.current = null;
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔍 Distance Search: 상태 초기화');
+    }
+  }, []);
+
+  const actions: SearchActions = {
+    handleMapMove,
+    handleSearch,
+    updateSearchPosition,
+    reset,
+  };
+
+  return {
+    ...state,
+    ...actions,
+    
+    // 상수 노출 (테스트 및 디버깅용)
+    constants: {
+      SHOW_BUTTON_DISTANCE,
+    },
+  };
+};

--- a/src/features/kakao-map/hooks/useManualSearch.ts
+++ b/src/features/kakao-map/hooks/useManualSearch.ts
@@ -6,7 +6,9 @@ import { useCallback, useRef, useState } from 'react';
  */
 
 // 재검색 버튼이 표시되는 최소 이동 거리 (미터)
-const SHOW_BUTTON_DISTANCE = 200;
+const SHOW_BUTTON_DISTANCE = import.meta.env.VITE_SEARCH_DISTANCE_THRESHOLD 
+  ? parseInt(import.meta.env.VITE_SEARCH_DISTANCE_THRESHOLD) 
+  : 5000; // 기본값: 5km
 
 export interface SearchState {
   /** 재검색 버튼 표시 여부 */

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -9,6 +9,7 @@ import useKakaoLoader from '@kakao-map/hooks/useKakaoLoader';
  * 카카오 맵과 관련된 리소스를 로드하고, 지도 및 UI 컨트롤, 위치 제어, 하단 시트가 포함된 전체 지도 페이지를 렌더링합니다.
  *
  * 지도 UI 상태를 제공하는 컨텍스트로 하위 컴포넌트들을 감쌉니다.
+ * 거리 기반 재검색 기능이 항상 활성화되어 있습니다.
  *
  * @returns 지도와 관련된 UI가 포함된 React 요소
  */
@@ -23,6 +24,7 @@ function MapPage() {
           <MapControlsContainer />
           <LocationControlContainer />
         </div>
+        
         <BottomSheetContainer />
       </div>
     </MapUIProvider>


### PR DESCRIPTION
<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 환경 변수 파일 추가
[노션 링크](https://www.notion.so/env-22240e6da57480b98811dff30b73dd04?source=copy_link) 참고하여 각 env 에 추가해주세요


## 도입 이유

  - 자동/수동 검색 모드 구분 제거로 UX 단순화
  - 검색 위치 기준 일정 거리 이동 시에만 재검색 버튼 표시
  - 불필요한 API 호출 방지 및 사용자 의도 기반 검색 제공

 ## 주요 변경사항

  - useManualSearch → useDistanceBasedSearch로 리팩토링
  - 드래그 시 자동 검색 로직 제거
  - 환경 변수 VITE_SEARCH_DISTANCE_THRESHOLD로 거리 임계값 설정 가능
  - 재검색 버튼 위치를 filter tap 하단으로 조정

  ## 기술적 개선
  - ref 사용으로 상태 업데이트 안정화 및 깜박임 해결
  - 의존성 배열 최적화로 불필요한 리렌더링 방지
  - 거리 계산 캐싱으로 성능 향상

# 현재 UI 캡처

|기준 위치|1.5km 이상 지도 이동 시|재 검색 후 결과|
|:--:|:--:|:--:|
|
<img width="415" height="819" alt="image" src="https://github.com/user-attachments/assets/181b144d-c04b-4bfb-8c02-3dfacdec67de" />|<img width="415" height="819" alt="image" src="https://github.com/user-attachments/assets/7d7cb592-7466-452f-91b0-74d555628d23" />|<img width="415" height="819" alt="image" src="https://github.com/user-attachments/assets/5f593560-0387-42d3-b1e5-80aced49ba09" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지도에서 거리를 기준으로 수동 재검색 버튼이 나타나는 기능이 추가되었습니다.
  * 자동/수동 검색 모드를 전환할 수 있는 토글 UI가 도입되었습니다.
  * 모바일 및 데스크톱 환경에 최적화된 수동 검색 버튼이 제공됩니다.

* **문서**
  * README에 지도 재검색 거리 임계값 환경변수(`VITE_SEARCH_DISTANCE_THRESHOLD`) 설정 방법이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->