### PR TITLE
[FIX][UHYU-241] auth redirect 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AppRoutes } from '@/routes/AppRoutes';
 
 import { queryClient } from '@/shared/client';
-import { useUserStore } from '@/shared/store/useUserStore';
+import { AuthLogger, useUserStore } from '@/shared/store/useUserStore';
 
 function App() {
   const initializeAuth = useUserStore(state => state.initializeAuth);
@@ -18,6 +18,7 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <AuthLogger />
       <AppRoutes />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/features/user/api/endpoints.ts
+++ b/src/features/user/api/endpoints.ts
@@ -1,6 +1,6 @@
 export const USER_ENDPOINTS = {
   EXTRA_INFO: '/users/extra-info',
-  GET_USER_INFO: '/user',
+  USER: '/user',
   UPDATE_USER_INFO: '/user',
   CHECK_EMAIL: '/users/check-email',
   LOGOUT: '/auth/logout',

--- a/src/features/user/api/types.ts
+++ b/src/features/user/api/types.ts
@@ -70,3 +70,16 @@ export interface LogoutResponse {
   code: string;
   message: string;
 }
+
+// userInfo 새롭게 타입 작성. 기존 타입 추후 삭제 예정
+export interface UserInfomation {
+  profileImage: string;
+  userName: string;
+  nickName: string | null;
+  email: string;
+  age: number | null;
+  gender: UserGender | null;
+  grade: UserGrade | null;
+  markerId: number | null;
+  updatedAt: string;
+}

--- a/src/features/user/api/userApi.ts
+++ b/src/features/user/api/userApi.ts
@@ -1,4 +1,5 @@
 import { client } from '@/shared/client';
+import type { ApiResponse } from '@/shared/client/client.type';
 
 import { USER_ENDPOINTS } from './endpoints';
 import type {
@@ -8,7 +9,7 @@ import type {
   UpdateUserInfoResponse,
   UserExtraInfoRequest,
   UserExtraInfoResponse,
-  GetUserInfoResponse
+  UserInfomation,
 } from './types';
 
 export const userApi = {
@@ -33,11 +34,11 @@ export const userApi = {
   },
 
   // 유저 정보 조회
-  getUserInfo: async (): Promise<GetUserInfoResponse> => {
-    const response = await client.get<GetUserInfoResponse>(
-      USER_ENDPOINTS.GET_USER_INFO
+  getUserInfo: async (): Promise<UserInfomation> => {
+    const response = await client.get<ApiResponse<UserInfomation>>(
+      USER_ENDPOINTS.USER
     );
-    return response.data;
+    return response.data.data;
   },
 
   // 유저 정보 수정 - 마이페이지


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
- 쿠키 기반 로그인 인증 후, `/user` API에서 사용자 정보를 받아오지 못하는 문제를 수정.
- 응답 타입을 서버 구조에 맞게 재정의하고, Zustand store에서 정상적으로 상태를 반영하도록 구현.
- 실제 배포 환경에서 로그인 후 자동 유저 정보 로딩이 되는지 확인하기 위해 테스트 필요.

## 수정사항
- `UserInfo` 타입 서버 응답에 맞게 수정
- `userApi.getUserInfo()` 함수에서 공통 응답 래핑 구조(`ApiResponse<T>`) 적용

## 추후 해야할 작업
- [ ] 응답 타입이 제대로 적용되어있지 않은 나머지 응답도 수정 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 로그인할 때 콘솔에 환영 메시지를 출력하는 기능이 추가되었습니다.

* **버그 수정**
  * 사용자 정보 관련 일부 동작이 더 안정적으로 처리되도록 개선되었습니다.

* **리팩터링**
  * 사용자 정보 타입이 일부 필드가 널 허용으로 변경되고, 업데이트 시간을 포함하도록 수정되었습니다.
  * 사용자 상태 관리 및 관련 메서드 구현이 간소화되고 일관성 있게 개선되었습니다.

* **기타**
  * 내부 상수 및 타입 명칭이 더 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->