### PR TITLE
chore: 사이드바에서 로그인 여부 확인

### DIFF
--- a/src/features/kakao-map/components/SidebarSheet.tsx
+++ b/src/features/kakao-map/components/SidebarSheet.tsx
@@ -1,6 +1,9 @@
-import { LoginButton } from '@home/components/LoginButton';
+import { useEffect, useState } from 'react';
+
+import { USER_ENDPOINTS } from '@user/index';
 import { Menu } from 'lucide-react';
 
+import { client } from '@/shared/client';
 import {
   Sheet,
   SheetContent,
@@ -9,7 +12,33 @@ import {
   SheetTrigger,
 } from '@/shared/components/shadcn/ui/sheet';
 
+interface UserInfo {
+  userName: string;
+  email: string;
+  profileImage?: string;
+}
+
 const SidebarSheet = () => {
+  const [user, setUser] = useState<UserInfo | null>(null);
+
+  // 페이지 로드될 때 유저 정보 요청
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await client.get(USER_ENDPOINTS.USER, {});
+        setUser(response.data.data); // 응답 구조에 맞게 조정 필요
+      } catch (error) {
+        console.warn('로그인 안 된 상태 또는 에러 발생:', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  const handleLogin = () => {
+    window.location.href = import.meta.env.VITE_KAKAO_LOGIN_URL;
+  };
+
   return (
     <Sheet modal={false}>
       <SheetTrigger asChild>
@@ -24,8 +53,20 @@ const SidebarSheet = () => {
         <SheetHeader>
           <SheetTitle>U-HYU</SheetTitle>
         </SheetHeader>
-        <div className="px-8">
-          <LoginButton />
+
+        <div className="px-8 mt-4">
+          {user ? (
+            <p className="text-base font-semibold">
+              안녕하세요, {user.userName}님!
+            </p>
+          ) : (
+            <button
+              onClick={handleLogin}
+              className="w-full bg-yellow-400 hover:bg-yellow-500 text-white py-2 rounded-xl font-bold"
+            >
+              카카오 로그인
+            </button>
+          )}
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 로그인된 사용자의 경우, 사이드바에서 사용자 이름이 포함된 인사말이 표시됩니다.
  * 로그인하지 않은 경우, 카카오 로그인 버튼이 표시되어 클릭 시 로그인 페이지로 이동합니다.

* **버그 수정**
  * 사용자 정보 조회 중 오류가 발생해도 UI가 정상적으로 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->