### PR TITLE
[FEAT][UHYU-245] AddStore 컴포넌트 즐겨찾기 api 연동 및 UX 수정

### DIFF
--- a/src/features/mymap/components/mymap-add-store/AddStore.tsx
+++ b/src/features/mymap/components/mymap-add-store/AddStore.tsx
@@ -62,6 +62,7 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
   const handleBookmarkToggle = (checked: boolean) => {
     setIsBookmarked(checked);
   };
+  
   // 지도 생성 모달
   const handleCreate = () => {
     openModal('base', {
@@ -100,7 +101,10 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
       <AddMyMapButton onCreateNewMap={handleCreate} />
 
       {/* 즐겨찾기 */}
-      <div className="flex items-center justify-between py-3">
+      <div
+        className="flex items-center justify-between py-3"
+        onClick={() => handleBookmarkToggle(!isBookmarked)}
+      >
         <div className="flex flex-row">
           <MdStars className="w-5 h-5 text-primary mr-2" />
           <span className="text-body2 font-semibold">즐겨찾기</span>
@@ -108,6 +112,7 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
         <PrimaryCheckbox
           checked={isBookmarked}
           onCheckedChange={handleBookmarkToggle}
+          onClick={e => e.stopPropagation()}
         />
       </div>
 
@@ -119,6 +124,7 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
           <div
             key={map.myMapListId}
             className="flex items-center justify-between py-3 rounded"
+            onClick={() => handleCheckToggle(map.myMapListId, !isChecked)}
           >
             <div className="flex flex-9 items-center">
               <MdStars
@@ -133,6 +139,7 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
               onCheckedChange={checked =>
                 handleCheckToggle(map.myMapListId, checked as boolean)
               }
+              onClick={e => e.stopPropagation()}
             />
           </div>
         );

--- a/src/features/mymap/components/mymap-add-store/AddStore.tsx
+++ b/src/features/mymap/components/mymap-add-store/AddStore.tsx
@@ -1,5 +1,6 @@
 import { type FC, useEffect, useState } from 'react';
 
+import { useToggleFavoriteMutation } from '@kakao-map/hooks/useMapQueries';
 import { MYMAP_COLOR, type MarkerColor } from '@mymap/constants/mymapColor';
 import { useStoreBookmarkStatusQuery } from '@mymap/hooks/useStoreBookmarkStatusQuery';
 import { useToggleMyMapStoreMutation } from '@mymap/hooks/useToggleMyMapStoreMutation';
@@ -18,14 +19,21 @@ interface AddStoreProps {
 const AddStore: FC<AddStoreProps> = ({ storeId }) => {
   const { data, isLoading, isError } = useStoreBookmarkStatusQuery(storeId);
   const toggleMutation = useToggleMyMapStoreMutation();
+  const toggleFavoriteMutation = useToggleFavoriteMutation();
   const openModal = useModalStore(state => state.openModal);
 
-  // 초기 체크 상태 저장용
+  // my map 초기 체크 상태 저장용
   const [initialCheckedMap, setInitialCheckedMap] = useState<
     Record<number, boolean>
   >({});
-  // 현재 체크 상태
+  // my map 현재 체크 상태
   const [checkedMap, setCheckedMap] = useState<Record<number, boolean>>({});
+
+  // 즐겨찾기 초기 체크 상태 저장용
+  const [initialIsBookmarked, setInitialIsBookmarked] = useState(false);
+
+  // 즐겨찾기 현재 체크 상태
+  const [isBookmarked, setIsBookmarked] = useState(false);
 
   // 데이터 로딩 후 초기값 저장
   useEffect(() => {
@@ -35,6 +43,10 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
       );
       setInitialCheckedMap(initial);
       setCheckedMap(initial);
+    }
+    if (typeof data?.isBookmarked === 'boolean') {
+      setInitialIsBookmarked(data.isBookmarked);
+      setIsBookmarked(data.isBookmarked);
     }
   }, [data]);
 
@@ -46,12 +58,10 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
     }));
   };
 
-  // 즐겨찾기 토글 (현재는 표시만 하고 있어서 기능 추가 필요)
+  // 즐겨찾기 토글
   const handleBookmarkToggle = (checked: boolean) => {
-    // TODO: 즐겨찾기 토글 API 호출 구현 필요
-    console.log('즐겨찾기 토글:', checked);
+    setIsBookmarked(checked);
   };
-
   // 지도 생성 모달
   const handleCreate = () => {
     openModal('base', {
@@ -62,6 +72,12 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
 
   // 저장 버튼 클릭 시 변경된 것만 요청
   const handleSave = () => {
+    // 즐겨찾기 상태 변경 감지
+    if (initialIsBookmarked !== isBookmarked) {
+      toggleFavoriteMutation.mutate({ storeId });
+    }
+
+    // MyMap 항목 변경 감지
     Object.entries(checkedMap).forEach(([id, isChecked]) => {
       const myMapListId = Number(id);
       const initial = initialCheckedMap[myMapListId];
@@ -89,8 +105,8 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
           <MdStars className="w-5 h-5 text-primary mr-2" />
           <span className="text-body2 font-semibold">즐겨찾기</span>
         </div>
-        <PrimaryCheckbox 
-          checked={data.isBookmarked} 
+        <PrimaryCheckbox
+          checked={isBookmarked}
           onCheckedChange={handleBookmarkToggle}
         />
       </div>
@@ -102,7 +118,7 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
         return (
           <div
             key={map.myMapListId}
-            className="flex items-center justify-between py-3 rounded hover:bg-light-gray-hover"
+            className="flex items-center justify-between py-3 rounded"
           >
             <div className="flex flex-9 items-center">
               <MdStars
@@ -112,9 +128,11 @@ const AddStore: FC<AddStoreProps> = ({ storeId }) => {
               />
               <span className="ml-2 text-body2 font-semibold">{map.title}</span>
             </div>
-            <PrimaryCheckbox 
-              checked={isChecked} 
-              onCheckedChange={(checked) => handleCheckToggle(map.myMapListId, checked as boolean)}
+            <PrimaryCheckbox
+              checked={isChecked}
+              onCheckedChange={checked =>
+                handleCheckToggle(map.myMapListId, checked as boolean)
+              }
             />
           </div>
         );

--- a/src/features/mymap/components/mymap-list/AddMyMapButton.tsx
+++ b/src/features/mymap/components/mymap-list/AddMyMapButton.tsx
@@ -8,7 +8,7 @@ const AddMyMapButton: React.FC<AddMyMapButtonProps> = ({ onCreateNewMap }) => {
   return (
     <button
       onClick={onCreateNewMap}
-      className="flex items-center text-primary font-bold text-body1 py-2 hover:bg-light-gray-hover cursor-pointer transition-colors"
+      className="flex items-center text-primary font-bold text-body1 py-2 cursor-pointer transition-colors"
     >
       <FiPlusCircle className="mr-2" /> 새 지도 만들기
     </button>


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
1. useToggleFavoriteMutation이 저장 버튼 클릭 시 호출되도록 즐겨찾기 상태 반영 로직 구현

2. 즐겨찾기, MyMap 리스트  영역을 클릭하면 체크 상태가 토글되도록 UX 개선

# 현재 UI 캡처

|UX 변경|
|:--:|
|![2025-07-281 02 01-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ecdfabdc-a502-4238-ba22-92587ecff3cf)|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 즐겨찾기(북마크) 상태를 UI에서 직접 토글할 수 있는 기능이 추가되었습니다.

* **스타일**
  * 버튼 및 지도 리스트 항목에서 호버(hover) 배경 효과가 제거되어 시각적 변화가 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->