### PR TITLE
[REFACTOR][UHYU-268] 에러처리 수정 및 최신 imageUrl 캐싱 및 반영되게 수정

### DIFF
--- a/src/features/barcode/hooks/useBarcodeImageQuery.ts
+++ b/src/features/barcode/hooks/useBarcodeImageQuery.ts
@@ -6,6 +6,6 @@ export const useBarcodeImageQuery = () => {
   return useQuery({
     queryKey: BARCODE_IMAGE_QUERY_KEY,
     queryFn: getBarcodeImage,
-    staleTime: Infinity, // 무조건 최신 데이터로 간주.
+    staleTime: 0, //업로드 후 반영
   });
 };


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
바코드 이미지 에러처리 수정 및 최신 imageUrl 캐싱 및 반영되게 수정

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 바코드 이미지 업로드 또는 수정 후 최신 이미지를 자동으로 불러오도록 개선되었습니다.
  * 특정 오류 코드(4103)에 해당하는 경우 오류 메시지가 표시되지 않도록 오류 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->