### PR TITLE
[UHYU-278] [FEAT] : StoreInfoWindwo 에서 즐겨찾기 버튼 클릭시 AddStore 모달 렌더링

### DIFF
--- a/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
+++ b/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
+import AddStore from '@mymap/components/mymap-add-store/AddStore';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
+
+import { useModalStore } from '@/shared/store';
 
 import { useStoreDetailQuery } from '../../hooks/useMapQueries';
 import StoreDetailCard from '../card/StoreDetailCard';
@@ -14,13 +17,20 @@ interface StoreInfoWindowProps {
 const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
   storeId,
   position,
-  handleToggleFavorite,
 }) => {
+  const openModal = useModalStore(state => state.openModal);
   const {
     data: storeDetailResponse,
     isLoading,
     error,
   } = useStoreDetailQuery(storeId);
+
+  const handleFavoriteClick = () => {
+    openModal('base', {
+      title: '매장 추가',
+      children: <AddStore storeId={storeId} />,
+    });
+  };
 
   if (isLoading) {
     return (
@@ -69,7 +79,7 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
           benefits={storeDetail.benefits}
           usageLimit={storeDetail.usageLimit}
           usageMethod={storeDetail.usageMethod}
-          handleToggleFavorite={handleToggleFavorite}
+          handleToggleFavorite={handleFavoriteClick}
         />
       </div>
     </CustomOverlayMap>


### PR DESCRIPTION
<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 현재 UI 캡처
매장 인포윈도우에서 즐겨찾기 클릭 시 AddStore 모달 렌더링 로직 추가

|AddStore Modal|
|:--:|
|<img width="1546" height="1640" alt="image" src="https://github.com/user-attachments/assets/e71285dd-0206-4dcd-9a57-500336c7aa41" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
