### PR TITLE
[FEAT][UHYU-277]  mymap page

### DIFF
--- a/src/features/mymap/components/MymapBody.tsx
+++ b/src/features/mymap/components/MymapBody.tsx
@@ -1,0 +1,148 @@
+import { AddMyMapButton } from '@mymap/components/mymap-list';
+import { MYMAP_COLOR, type MarkerColor } from '@mymap/constants/mymapColor';
+import { useMyMapListQuery } from '@mymap/hooks/useMyMapListQuery';
+import { BsThreeDotsVertical } from 'react-icons/bs';
+import { MdStars } from 'react-icons/md';
+import { MdIosShare } from 'react-icons/md';
+import { PiTrashBold } from 'react-icons/pi';
+import { RiPencilFill } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/components/shadcn/ui/dropdown-menu';
+import { useModalStore } from '@/shared/store';
+
+import { MyMapForm } from './InputMymap';
+import { MymapDeleteModal } from './MymapDeleteModal';
+import { ShareModal } from './ShareModal';
+
+const MyMapBody: React.FC = () => {
+  const { data, isLoading, isError } = useMyMapListQuery();
+  const openModal = useModalStore(state => state.openModal);
+  const navigate = useNavigate();
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError || !data) return <div>에러 발생</div>;
+
+  // 삭제 모달
+  const handleDelete = (mapId: number) => {
+    openModal('base', {
+      title: 'My Map 삭제',
+      children: <MymapDeleteModal mapId={mapId} />,
+    });
+  };
+
+  // 추후 uuid를 받아서 보내는 기능 추가
+  const handleShare = (uuid: string) => {
+    openModal('base', {
+      title: 'My Map 공유',
+      children: <ShareModal uuid={uuid} />,
+    });
+  };
+
+  // 수정 모달
+  const handleUpdate = (
+    myMapListId: number,
+    myMapTitle: string,
+    color: string
+  ) => {
+    openModal('base', {
+      title: '수정',
+      children: (
+        <MyMapForm
+          mode="edit"
+          myMapListId={myMapListId}
+          defaultTitle={myMapTitle}
+          defaultColor={color as MarkerColor}
+        />
+      ),
+    });
+  };
+
+  // 생성 모달
+  const handleCreate = () => {
+    openModal('base', {
+      title: '새 지도 만들기',
+      children: <MyMapForm mode="create" />,
+    });
+  };
+
+  return (
+    <div className="flex flex-col w-full max-w-md mx-auto divide-y divide-gray-200">
+      {/* 새 지도 만들기 */}
+      <AddMyMapButton onCreateNewMap={handleCreate} />
+
+      {/* map 리스트 */}
+      {data.length === 0 ? (
+        <div className="flex  text-sm text-gray-400 mt-4">
+          새 지도를 만들어주세요
+        </div>
+      ) : (
+        data.map(map => (
+          <div
+            key={map.myMapListId}
+            className="flex items-center justify-between py-3 cursor-pointer hover:bg-light-gray-hover rounded"
+          >
+            <div
+              className="flex flex-9 items-center"
+              onClick={() => navigate(`/map/${map.uuid}`)}
+            >
+              <MdStars
+                className={`w-5 h-5 ${MYMAP_COLOR[map.markerColor as MarkerColor] || MYMAP_COLOR.RED}`}
+              />
+              <span className="ml-2 text-body2 font-semibold">{map.title}</span>
+            </div>
+            {/* 수정, 삭제, 공유 드롭다운 버튼 */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <BsThreeDotsVertical className="flex-1 w-4 h-4 cursor-pointer" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="w-36 divide-gray-200 bg-white border-none"
+              >
+                <DropdownMenuItem
+                  onClick={() => {
+                    handleUpdate(map.myMapListId, map.title, map.markerColor);
+                  }}
+                  className="flex justify-between font-medium"
+                >
+                  수정
+                  <RiPencilFill className="mr-2 h-4 w-4" />
+                </DropdownMenuItem>
+                <hr />
+                <DropdownMenuItem
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleShare(map.uuid);
+                  }}
+                  className="flex justify-between font-medium"
+                >
+                  공유
+                  <MdIosShare className="mr-2 h-4 w-4" />
+                </DropdownMenuItem>
+                <hr />
+                <DropdownMenuItem
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleDelete(map.myMapListId);
+                  }}
+                  className="flex justify-between font-medium"
+                >
+                  삭제
+                  <PiTrashBold className="mr-2 h-4 w-4" />
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default MyMapBody;

--- a/src/features/mymap/components/MymapHeader.tsx
+++ b/src/features/mymap/components/MymapHeader.tsx
@@ -1,0 +1,8 @@
+export const MymapHeader = () => (
+  <div className="flex flex-col gap-4">
+    <p className="text-h3 font-bold text-black">MyMap</p>
+    <p className="text-caption text-black">
+      마이맵을 통해 나만의 제휴처 지도를 만들어보세요.
+    </p>
+  </div>
+);

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -5,3 +5,4 @@ export { default as ExtraInfo } from './user/extra-info/ExtraInfo';
 export { default as AdminPage } from './admin/AdminPage';
 export { default as MyPage } from './mypage/MyPage';
 export { default as MyPageActivity } from './mypage/MyPageActivity';
+export { default as MymapPage } from './mymap/MymapPage';

--- a/src/pages/mymap/MymapPage.tsx
+++ b/src/pages/mymap/MymapPage.tsx
@@ -1,0 +1,8 @@
+const MymapPage = () => {
+  return (
+    <div className="flex flex-col gap-4 pb-10">
+    </div>
+  );
+};
+
+export default MymapPage;

--- a/src/pages/mymap/MymapPage.tsx
+++ b/src/pages/mymap/MymapPage.tsx
@@ -1,6 +1,11 @@
+import MyMapBody from '@mymap/components/MymapBody';
+import { MymapHeader } from '@mymap/components/MymapHeader';
+
 const MymapPage = () => {
   return (
     <div className="flex flex-col gap-4 pb-10">
+      <MymapHeader />
+      <MyMapBody />
     </div>
   );
 };

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,19 +1,26 @@
 import { useEffect, useState } from 'react';
 
-
-
-import { AdminPage, BenefitPage, ExtraInfo, HomePage, MapPage, MyPage, MyPageActivity } from '@/pages';
+import {
+  AdminPage,
+  BenefitPage,
+  ExtraInfo,
+  HomePage,
+  MapPage,
+  MyPage,
+  MyPageActivity,
+  MymapPage,
+} from '@/pages';
 import SidebarSheet from '@kakao-map/components/SidebarSheet';
 import { PATH } from '@paths';
-import { BrowserRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom';
-
-
+import {
+  BrowserRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom';
 
 import { BaseLayout, BottomNavigation, ModalRoot } from '@/shared/components';
-
-
-
-
 
 const Layout = () => {
   const { pathname } = useLocation();
@@ -31,7 +38,7 @@ const Layout = () => {
   }, []);
 
   const showBottomNav =
-    pathname === PATH.HOME ||
+    pathname === PATH.MYMAP ||
     pathname === PATH.BENEFIT ||
     pathname.startsWith(PATH.MAP) ||
     pathname === PATH.MYPAGE ||
@@ -82,6 +89,7 @@ export const AppRoutes = () => {
           <Route path={PATH.MAP} element={<MapPage />} />
           <Route path="/map/:uuid" element={<MapPage />} />
           <Route path={PATH.ADMIN} element={<AdminPage />} />
+          <Route path={PATH.MYMAP} element={<MymapPage />} />
         </Route>
       </Routes>
       <ModalRoot />

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -1,5 +1,6 @@
 export const PATH = {
   HOME: '/',
+  MYMAP: '/mymap',
   MAP: '/map',
   BENEFIT: '/benefit',
   MYPAGE: '/mypage',

--- a/src/shared/components/bottom_navigation/BottomNavigation.tsx
+++ b/src/shared/components/bottom_navigation/BottomNavigation.tsx
@@ -44,13 +44,13 @@ const BottomNavigation = () => {
         <NavLink
           to={PATH.MYMAP}
           className="flex gap-4"
-          onClick={() => handleTabClick('마이앱')}
+          onClick={() => handleTabClick('마이맵')}
         >
           <NavItem
             label="마이맵"
             icon={<FaMap />}
-            isActive={activeTab === '마이앱'}
-            onClick={() => handleTabClick('마이앱')}
+            isActive={activeTab === '마이맵'}
+            onClick={() => handleTabClick('마이맵')}
           />
         </NavLink>
         <span />

--- a/src/shared/components/bottom_navigation/BottomNavigation.tsx
+++ b/src/shared/components/bottom_navigation/BottomNavigation.tsx
@@ -3,10 +3,10 @@ import { useState } from 'react';
 import { PATH } from '@paths';
 import { X } from 'lucide-react';
 import { FaMap } from 'react-icons/fa';
+import { FaMapMarkerAlt } from 'react-icons/fa';
 import { FaUser } from 'react-icons/fa6';
 import { HiGift } from 'react-icons/hi';
 import { LiaBarcodeSolid } from 'react-icons/lia';
-import { MdHomeFilled } from 'react-icons/md';
 import { NavLink } from 'react-router-dom';
 
 import BarcodeItem from '@/shared/components/bottom_navigation/BarcodeItem';
@@ -15,7 +15,7 @@ import NavItem from '@/shared/components/bottom_navigation/NavItem';
 import { BarcodeBottomSheet } from './barcode/BarcodeBottomSheet';
 
 const BottomNavigation = () => {
-  const [activeTab, setActiveTab] = useState<string>('홈');
+  const [activeTab, setActiveTab] = useState<string>('지도');
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleTabClick = (tab: string) => {
@@ -30,27 +30,27 @@ const BottomNavigation = () => {
     <div className="absolute bottom-0 left-0 right-0 z-1001">
       <nav className="h-12 text-[0.625rem] shadow-nav flex relative justify-around bg-white gap-5 px-[1.5rem] py-[0.5rem]">
         <NavLink
-          to={PATH.HOME}
-          className="flex gap-4"
-          onClick={() => handleTabClick('홈')}
-        >
-          <NavItem
-            label="홈"
-            icon={<MdHomeFilled />}
-            isActive={activeTab === '홈'}
-            onClick={() => handleTabClick('홈')}
-          />
-        </NavLink>
-        <NavLink
           to={PATH.MAP}
           className="flex gap-4"
           onClick={() => handleTabClick('지도')}
         >
           <NavItem
             label="지도"
-            icon={<FaMap />}
+            icon={<FaMapMarkerAlt />}
             isActive={activeTab === '지도'}
             onClick={() => handleTabClick('지도')}
+          />
+        </NavLink>
+        <NavLink
+          to={PATH.MYMAP}
+          className="flex gap-4"
+          onClick={() => handleTabClick('마이앱')}
+        >
+          <NavItem
+            label="마이맵"
+            icon={<FaMap />}
+            isActive={activeTab === '마이앱'}
+            onClick={() => handleTabClick('마이앱')}
           />
         </NavLink>
         <span />


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
- path에 mymap 추가
- mymappage 생성 및 인덱스 추가
- 앱라우터 및 네비게이션바 수정
- mymap page 구현

# 현재 UI 캡처

|UI 제목1|
|:--:|
|![2025-07-285 18 42-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/11c4a422-fbec-4d0a-90ec-f0a266760efc)|

## 체크리스트
- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 직접 만든 지도를 관리할 수 있는 "마이맵" 페이지가 추가되었습니다.
  * "마이맵"에서 지도 목록 확인, 생성, 수정, 공유, 삭제 기능을 지원합니다.
  * 각 지도 항목별로 상세 보기 및 관리 옵션(수정, 공유, 삭제)이 제공됩니다.

* **UI/네비게이션 개선**
  * 하단 네비게이션에서 "홈"이 "지도"로 변경되고, "지도"가 "마이맵"으로 교체되었습니다.
  * "마이맵" 페이지 진입 시 하단 네비게이션이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->