### PR TITLE
[FEAT][UHYU-280] 사용자 클릭 행동 패턴 수집 tracker 구현

### DIFF
--- a/src/features/benefit/components/BenefitList.tsx
+++ b/src/features/benefit/components/BenefitList.tsx
@@ -11,6 +11,7 @@ import { useGetBrandListQuery } from '@benefit/hooks/useGetBrandListQuery';
 import { BrandCard, FilterTabs, SearchInput } from '@/shared/components';
 import { BENEFIT_FILTER_TABS } from '@/shared/components/filter_tabs/FilterTabs.variants';
 import { useModalStore } from '@/shared/store';
+import { trackFilterUsed } from '@/shared/utils/actionlogTracker';
 
 export const BenefitList = () => {
   const { params, setParam, setParams } = useBenefitQueryParams();
@@ -33,6 +34,15 @@ export const BenefitList = () => {
     });
   };
 
+  const handleFilterChange = (value: string) => {
+    setParam('category', value); // 기존 로직 유지
+
+    // 🎯 행동 추적 추가
+    if (value !== 'all' && value !== '전체') {
+      trackFilterUsed(value);
+    }
+  };
+
   return (
     <div>
       {/* 필터링 */}
@@ -42,10 +52,7 @@ export const BenefitList = () => {
           onChange={setSearchTerm}
           onSearch={value => setParam('brand_name', value)}
         />
-        <FilterTabs
-          tabs={BENEFIT_FILTER_TABS}
-          onChange={value => setParam('category', value)}
-        />
+        <FilterTabs tabs={BENEFIT_FILTER_TABS} onChange={handleFilterChange} />
         <CheckBoxList
           selectedItems={{
             storeType: params.storeType ?? '',

--- a/src/features/kakao-map/components/layout/StoreListContent.tsx
+++ b/src/features/kakao-map/components/layout/StoreListContent.tsx
@@ -5,6 +5,7 @@ import { RecommendedStoreList } from '@recommendation/components/RecommendedStor
 
 import { BrandCard } from '@/shared/components';
 import { useIsLoggedIn } from '@/shared/store/userStore';
+import { trackMarkerClick } from '@/shared/utils/actionlogTracker';
 
 interface StoreListContentProps {
   stores: Store[];
@@ -17,6 +18,12 @@ const StoreListContent: FC<StoreListContentProps> = ({
   onStoreClick,
 }) => {
   const isLoggedIn = useIsLoggedIn();
+
+  const handleStoreClick = (store: Store) => {
+    onStoreClick?.(store);
+    trackMarkerClick(store.storeId);
+  };
+
   return (
     <div className="flex flex-col h-full">
       {/* 필터 헤더 - 고정 */}
@@ -38,7 +45,7 @@ const StoreListContent: FC<StoreListContentProps> = ({
               <div
                 key={store.storeId}
                 className="p-4 hover:bg-gray-50 transition-colors cursor-pointer"
-                onClick={() => onStoreClick?.(store)}
+                onClick={() => handleStoreClick(store)}
               >
                 <BrandCard logoUrl={store.logo_image}>
                   <div className="flex-1 min-w-0">

--- a/src/features/kakao-map/components/layout/steps/CategorySelectContent.tsx
+++ b/src/features/kakao-map/components/layout/steps/CategorySelectContent.tsx
@@ -1,7 +1,10 @@
 import { type FC } from 'react';
+
+import { trackFilterUsed } from '@/shared/utils/actionlogTracker';
+
 import {
-  FILTERED_CATEGORIES,
   type CategoryType,
+  FILTERED_CATEGORIES,
 } from '../../../constants/categories';
 import type { StoreCategory } from '../../../types/category';
 
@@ -18,6 +21,11 @@ const CategorySelectContent: FC<CategorySelectContentProps> = ({
 
   const handleCategoryClick = (categoryKey: StoreCategory) => {
     onCategorySelect(categoryKey);
+
+    // 행동 추적 추가
+    if (categoryKey !== 'all') {
+      trackFilterUsed(categoryKey);
+    }
   };
 
   return (

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -3,6 +3,8 @@ import { type FC, useCallback, useEffect, useRef, useState } from 'react';
 import { useSharedMapStore } from '@mymap/store/SharedMapStore';
 import { CustomOverlayMap, Map as KakaoMap } from 'react-kakao-maps-sdk';
 
+import { trackMarkerClick } from '@/shared/utils/actionlogTracker';
+
 import { useDistanceBasedSearch } from '../../hooks/useManualSearch';
 import { useToggleFavoriteMutation } from '../../hooks/useMapQueries';
 import type { Store } from '../../types/store';
@@ -116,6 +118,8 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
     (store: Store) => {
       setInternalSelectedStoreId(store.storeId);
       setInfoWindowStore(store);
+
+      trackMarkerClick(store.storeId);
 
       // 인포 윈도우가 화면 중앙에 오도록 오프셋 적용
       const offset = 0.0017;

--- a/src/shared/components/filter_tabs/FilterTabs.tsx
+++ b/src/shared/components/filter_tabs/FilterTabs.tsx
@@ -8,6 +8,7 @@ import {
   FILTER_TABS,
   filterTabVariants,
 } from '@/shared/components/filter_tabs/FilterTabs.variants';
+import { trackFilterUsed } from '@/shared/utils/actionlogTracker';
 
 const FilterTabs: FC<FilterTabProps> = ({
   tabs = FILTER_TABS,
@@ -19,6 +20,11 @@ const FilterTabs: FC<FilterTabProps> = ({
   const handleClick = (value: string) => {
     setActive(value);
     onChange?.(value);
+
+    // 🎯 이게 전부!
+    if (value !== 'all') {
+      trackFilterUsed(value); // 'shopping' 그대로 전달
+    }
   };
 
   return (

--- a/src/shared/hooks/useMapMarkerActionTracking.ts
+++ b/src/shared/hooks/useMapMarkerActionTracking.ts
@@ -1,0 +1,36 @@
+import { getCategoryId } from '@kakao-map/constants/categoryMapping';
+import type { StoreCategory } from '@kakao-map/types/category';
+import type { Store } from '@kakao-map/types/store';
+
+import {
+  getFilterUsageCount,
+  getMarkerClickCount,
+  trackFilterUsed,
+  trackMarkerClick,
+} from '@/shared/utils/actionlogTracker';
+
+export const useMapMarkerActionTracking = () => {
+  const handleMarkerClick = (store: Store) => {
+    trackMarkerClick(store.storeId);
+  };
+
+  const handleFilterClick = (categoryKey: string) => {
+    if (categoryKey !== 'all') {
+      const categoryId = getCategoryId(categoryKey as StoreCategory);
+      if (categoryId > 0) {
+        trackFilterUsed(categoryKey);
+      }
+    }
+  };
+
+  const getMarkerCount = (storeId: number) => getMarkerClickCount(storeId);
+  const getFilterCount = (categoryKey: string) =>
+    getFilterUsageCount(categoryKey);
+
+  return {
+    handleMarkerClick,
+    handleFilterClick,
+    getMarkerCount,
+    getFilterCount,
+  };
+};

--- a/src/shared/types/actionlogTracker.types.ts
+++ b/src/shared/types/actionlogTracker.types.ts
@@ -1,0 +1,10 @@
+export interface UserAction {
+  actionType: 'MARKER_CLICK' | 'FILTER_USED';
+  storeId?: number | null;
+  categoryId?: number | null;
+}
+
+export interface CounterData {
+  markerClicks: Record<number, number>; //<storeId, count>
+  filterClicks: Record<number, number>; //<categoryId, count>
+}

--- a/src/shared/utils/actionlogTracker.ts
+++ b/src/shared/utils/actionlogTracker.ts
@@ -243,7 +243,7 @@ export const getMarkerClickCount = (storeId: number) => {
 };
 
 export const getFilterUsageCount = (categoryName: string) => {
-  return getActionLogCounter().addFilterClick(categoryName);
+  return getActionLogCounter().getFilterClickCount(categoryName);
 };
 
 export const forceFlushCounters = () => {

--- a/src/shared/utils/actionlogTracker.ts
+++ b/src/shared/utils/actionlogTracker.ts
@@ -1,0 +1,255 @@
+import { client } from '@/shared/client';
+import type {
+  CounterData,
+  UserAction,
+} from '@/shared/types/actionlogTracker.types';
+import { getCategoryIdFromFilterValue } from '@/shared/utils/categoryMapper';
+
+const CLICK_THRESHOLD = 15;
+const STORAGE_KEY = 'Action_log';
+const ENDPOINTS_ACTION_LOG = '/user/action-logs';
+
+// TODO: 주석 관련 코드 삭제 필요
+class ActionLogCounter {
+  private markerClicks: Map<number, number> = new Map();
+  private filterClicks: Map<string, number> = new Map();
+
+  constructor() {
+    //클래스가 처음 생성될 때 실행되는 초기화 함수
+    this.loadFromStorage(); //로컬 스토리지에 저장된 데이터를 불러옴.
+    this.setupPageUnloadHandler(); //페이지를 닫거나 새로고침할 때 데이터를 저장하는 이벤트 등록
+  }
+
+  private loadFromStorage() {
+    // 로컬 스토리지에서 카운터 데이터 로드
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const data: CounterData = JSON.parse(stored);
+
+        this.markerClicks = new Map(
+          Object.entries(data.markerClicks).map(([k, v]) => [parseInt(k), v])
+        );
+        this.filterClicks = new Map(Object.entries(data.filterClicks || {}));
+
+        if (import.meta.env.MODE === 'development') {
+          console.log('📊 Loaded counters from storage:', {
+            markerClicks: Object.fromEntries(this.markerClicks),
+            filterClicks: Object.fromEntries(this.filterClicks),
+          });
+        }
+      }
+    } catch (error) {
+      console.error('스토리지 카운터 로드 실패', error);
+    }
+  }
+
+  private saveToStorage() {
+    // 로컬 스토리지에 카운터 데이터 저장
+    try {
+      const data: CounterData = {
+        markerClicks: Object.fromEntries(this.markerClicks),
+        filterClicks: Object.fromEntries(this.filterClicks),
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (error) {
+      console.error('스토리지에 카운터 데이터 저장 실패', error);
+    }
+  }
+
+  addMarkerClick(storeId: number) {
+    //마커 클릭 추가
+    const currentCount = this.markerClicks.get(storeId) || 0;
+    const newCount = currentCount + 1;
+    this.markerClicks.set(storeId, newCount);
+
+    if (import.meta.env.MODE === 'development') {
+      console.log(
+        `🎃🎃🎃🎃🎃 Store: ${storeId} clicked: ${newCount} / ${CLICK_THRESHOLD}`
+      );
+    }
+
+    if (newCount >= CLICK_THRESHOLD) {
+      // 임계점 도달시
+      this.sendMarkerClickData(storeId);
+      this.markerClicks.delete(storeId);
+    }
+
+    this.saveToStorage();
+  }
+
+  addFilterClick(filterValue: string) {
+    const currentCount = this.filterClicks.get(filterValue) || 0;
+    const newCount = currentCount + 1;
+    this.filterClicks.set(filterValue, newCount);
+
+    if (import.meta.env.MODE === 'development') {
+      console.log(
+        `🎃🎃🎃🎃🎃 Category ${filterValue} filtered: ${newCount} / ${CLICK_THRESHOLD}`
+      );
+    }
+
+    if (newCount >= CLICK_THRESHOLD) {
+      this.sendFilterClickData(filterValue);
+      this.filterClicks.delete(filterValue);
+    }
+
+    this.saveToStorage();
+  }
+
+  // 마커 클릭 데이터 전송
+  private async sendMarkerClickData(storeId: number) {
+    const actionData: UserAction = {
+      actionType: 'MARKER_CLICK',
+      storeId,
+      categoryId: null,
+    };
+    await this.sendToServer([actionData]);
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🎃🎃🎃🎃🎃 🚀 Marker click data sent:', actionData);
+    }
+  }
+
+  private async sendFilterClickData(filterValue: string) {
+    const categoryId = getCategoryIdFromFilterValue(filterValue);
+    const actionData: UserAction = {
+      actionType: 'FILTER_USED',
+      storeId: null,
+      categoryId,
+    };
+
+    await this.sendToServer([actionData]);
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🎃🎃🎃🎃🎃 🚀 Filter usage data sent:', actionData);
+    }
+  }
+
+  private async sendToServer(actions: UserAction[]) {
+    try {
+      const res = await client.post(ENDPOINTS_ACTION_LOG, { actions });
+      if (import.meta.env.MODE === 'development') {
+        console.log('🎃🎃🎃🎃🎃 ✅ Behavior data sent successfully:', res.data);
+      }
+
+      this.saveToStorage();
+    } catch (error) {
+      console.error('🎃🎃🎃🎃🎃 Failed to send behavior data:', error);
+    }
+  }
+
+  getCounters() {
+    return {
+      markerClicks: Object.fromEntries(this.markerClicks),
+      filterClicks: Object.fromEntries(this.filterClicks),
+    };
+  }
+
+  getMarkerClickCount(storeId: number): number {
+    return this.markerClicks.get(storeId) || 0;
+  }
+
+  getFilterClickCount(filterValue: string): number {
+    return this.filterClicks.get(filterValue) || 0;
+  }
+
+  private setupPageUnloadHandler() {
+    if (typeof window === 'undefined') return;
+
+    window.addEventListener('beforeunload', () => {
+      this.saveToStorage();
+
+      if (import.meta.env.MODE === 'development') {
+        console.log('Counters saved on page unload');
+      }
+    });
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        this.saveToStorage();
+      }
+    });
+  }
+
+  async forceFlush() {
+    const actions: UserAction[] = [];
+
+    // 현재 카운터가 있는 모든 항목을 전송
+    for (const [storeId, count] of this.markerClicks.entries()) {
+      if (count > 0) {
+        actions.push({
+          actionType: 'MARKER_CLICK',
+          storeId,
+          categoryId: null,
+        });
+      }
+    }
+
+    for (const [filterValue, count] of this.filterClicks.entries()) {
+      if (count > 0) {
+        const categoryId = getCategoryIdFromFilterValue(filterValue);
+        actions.push({
+          actionType: 'FILTER_USED',
+          storeId: null,
+          categoryId,
+        });
+      }
+    }
+
+    if (actions.length > 0) {
+      await this.sendToServer(actions);
+      this.markerClicks.clear();
+      this.filterClicks.clear();
+      this.saveToStorage();
+    }
+  }
+
+  // 카운터 초기화
+  reset() {
+    this.markerClicks.clear();
+    this.filterClicks.clear();
+    localStorage.removeItem(STORAGE_KEY);
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🗑️ All counters reset');
+    }
+  }
+}
+
+let actionLogCounter: ActionLogCounter | null = null;
+
+const getActionLogCounter = (): ActionLogCounter => {
+  if (!actionLogCounter) {
+    actionLogCounter = new ActionLogCounter();
+  }
+  return actionLogCounter;
+};
+
+export const trackMarkerClick = (storeId: number) => {
+  getActionLogCounter().addMarkerClick(storeId);
+};
+
+export const trackFilterUsed = (filterValue: string) => {
+  getActionLogCounter().addFilterClick(filterValue);
+};
+
+export const getCounters = () => {
+  return getActionLogCounter().getCounters();
+};
+
+export const getMarkerClickCount = (storeId: number) => {
+  return getActionLogCounter().getMarkerClickCount(storeId);
+};
+
+export const getFilterUsageCount = (categoryName: string) => {
+  return getActionLogCounter().addFilterClick(categoryName);
+};
+
+export const forceFlushCounters = () => {
+  return getActionLogCounter().forceFlush();
+};
+
+export const resetCounters = () => {
+  getActionLogCounter().reset();
+};

--- a/src/shared/utils/categoryMapper.ts
+++ b/src/shared/utils/categoryMapper.ts
@@ -1,0 +1,54 @@
+export const getCategoryIdFromFilterValue = (filterValue: string): number => {
+  const categoryMapping: Record<string, number> = {
+    'APP/기기': 1,
+
+    '영화/미디어': 2,
+    culture: 2,
+    '문화/여가': 2,
+
+    '워터파크/아쿠아리움': 3,
+
+    액티비티: 4,
+    activity: 4,
+
+    뷰티: 5,
+    beauty: 5,
+    '뷰티/건강': 5,
+    '뷰티(피부과, 클리닉)': 5,
+
+    건강: 6,
+    '건강(제약, 영양제 등)': 6,
+
+    '생활/편의': 7,
+    life: 7,
+
+    쇼핑: 8,
+    shopping: 8,
+
+    음식점: 9,
+    food: 9,
+    푸드: 9,
+
+    '베이커리/디저트': 10,
+
+    테마파크: 11,
+
+    '공연/전시': 12,
+
+    교육: 13,
+    education: 13,
+
+    '여행/교통': 14,
+    travel: 14,
+  };
+
+  const categoryId = categoryMapping[filterValue];
+
+  if (categoryId === undefined) {
+    if (import.meta.env.MODE === 'development') {
+      console.log(`알 수 없는 값 : ${filterValue}`);
+    }
+    return 0;
+  }
+  return categoryId;
+};


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
클릭 트래킹이 동작하도록 구현. 아래 목록에서 수집 가능
> 카테고리 탭 클릭 - 지도/제휴처 리스트 
> store 클릭 - 지도(마커, 카드)

임계점 도달 (15회) → 서버로 액션 전송 -> 카운트 초기화 → 해당 카운트 리셋
localstorage기반 데이터 보존

**각 컴포넌트에 트래킹 코드 추가 및 onClick 핸들러 구현 되어있을 수 있습니다!**

- [ ] 배포 후 테스트해서 전송이 되는지 확인 필요

# 현재 UI 캡처

|카테고리 15회 클릭 시|스토어 15회 클릭 시|
|:--:|:--:|
|<img width="405" alt="image" src="https://github.com/user-attachments/assets/178bbb99-849a-4085-9fed-d65625100e7c" />|<img width="405" alt="image" src="https://github.com/user-attachments/assets/604ab94c-d4d3-48f2-bde6-9c373d2e8ebc" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
