### PR TITLE
[FEAT][UHYU-279] 제휴 매장 인포윈도우 긴글 처리 (더보기 로직) 및 애니메이션 도입

### DIFF
--- a/src/features/kakao-map/api/mockData.ts
+++ b/src/features/kakao-map/api/mockData.ts
@@ -563,9 +563,12 @@ export const MOCK_STORE_DETAILS: Record<number, StoreDetail> = {
     storeName: 'CGV 강남점',
     isFavorite: false,
     favoriteCount: 245,
-    benefits: 'CGV 골드클래스 할인, VIP 라운지 이용',
-    usageLimit: '월 3회',
-    usageMethod: 'CGV 앱에서 예매 시 자동 적용',
+    benefits:
+      'CGV 골드클래스 할인 30%, VIP 라운지 무료 이용, 팝콘세트 50% 할인, 생일자 무료 영화 관람권 증정, CGV 포인트 2배 적립, 프리미엄 좌석 우선 예매, 스낵바 할인 쿠폰 제공, 영화 관람 후 리뷰 작성 시 추가 포인트 적립',
+    usageLimit:
+      '월 3회 사용 가능하며, 매월 1일 자정에 사용 횟수가 초기화됩니다. 연속 3개월 미사용 시 혜택이 일시 중단될 수 있습니다.',
+    usageMethod:
+      'CGV 앱에서 예매 시 자동 적용되며, 현장 매표소에서도 할인코드를 제시하면 동일한 혜택을 받을 수 있습니다. 온라인 예매 시에는 로그인 후 U+ 멤버십 인증을 완료해야 합니다.',
   },
   2: {
     storeName: '롯데시네마 강남역점',

--- a/src/features/kakao-map/components/card/StoreDetailCard.tsx
+++ b/src/features/kakao-map/components/card/StoreDetailCard.tsx
@@ -47,19 +47,6 @@ const ExpandButton: React.FC<{
   </button>
 );
 
-// 개선된 애니메이션 변형
-const expandVariants = {
-  collapsed: { 
-    opacity: 1 
-  },
-  expanded: { 
-    opacity: 1,
-    transition: {
-      duration: 0.3,
-      ease: [0.25, 0.46, 0.45, 0.94]
-    }
-  }
-};
 
 const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
   storeName,
@@ -155,44 +142,18 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
               <span>{userGrade}</span>
             </div>
             <div className="bg-yellow-50 px-3 py-1 rounded-tr rounded-br text-sm flex-1 min-w-0">
-              <div className="break-words text-left overflow-hidden">
-                <motion.div
-                  layout
-                  animate={{ 
-                    height: expandedSections.benefits ? 'auto' : 'auto'
-                  }}
-                  transition={{
-                    duration: 0.4,
-                    ease: [0.25, 0.46, 0.45, 0.94]
-                  }}
-                >
-                  <motion.span 
-                    className="whitespace-pre-wrap block"
-                    animate={{
-                      opacity: 1
-                    }}
-                    transition={{
-                      duration: 0.2,
-                      delay: expandedSections.benefits ? 0 : 0.1
-                    }}
-                  >
-                    {expandedSections.benefits 
-                      ? benefits 
-                      : getTruncatedText(benefits, TEXT_LIMITS.benefits)
-                    }
-                  </motion.span>
-                </motion.div>
+              <div className="break-words text-left">
+                <span className="whitespace-pre-wrap block">
+                  {expandedSections.benefits 
+                    ? benefits 
+                    : getTruncatedText(benefits, TEXT_LIMITS.benefits)
+                  }
+                </span>
                 {shouldShowExpand(benefits, TEXT_LIMITS.benefits) && (
-                  <motion.div
-                    initial={{ opacity: 0, y: -5 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.2, delay: 0.1 }}
-                  >
-                    <ExpandButton
-                      isExpanded={expandedSections.benefits}
-                      onClick={() => toggleSection('benefits')}
-                    />
-                  </motion.div>
+                  <ExpandButton
+                    isExpanded={expandedSections.benefits}
+                    onClick={() => toggleSection('benefits')}
+                  />
                 )}
               </div>
             </div>
@@ -204,88 +165,36 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
         <div className="text-sm font-semibold text-gray-700 mb-2">
           제공 횟수
         </div>
-        <div className="text-sm overflow-hidden">
-          <motion.div
-            layout
-            animate={{ 
-              height: expandedSections.usageLimit ? 'auto' : 'auto'
-            }}
-            transition={{
-              duration: 0.4,
-              ease: [0.25, 0.46, 0.45, 0.94]
-            }}
-          >
-            <motion.span 
-              className="break-words whitespace-pre-wrap block"
-              animate={{
-                opacity: 1
-              }}
-              transition={{
-                duration: 0.2,
-                delay: expandedSections.usageLimit ? 0 : 0.1
-              }}
-            >
-              {expandedSections.usageLimit 
-                ? usageLimit 
-                : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)
-              }
-            </motion.span>
-          </motion.div>
+        <div className="text-sm">
+          <span className="break-words whitespace-pre-wrap block">
+            {expandedSections.usageLimit 
+              ? usageLimit 
+              : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)
+            }
+          </span>
           {shouldShowExpand(usageLimit, TEXT_LIMITS.usageLimit) && (
-            <motion.div
-              initial={{ opacity: 0, y: -5 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, delay: 0.1 }}
-            >
-              <ExpandButton
-                isExpanded={expandedSections.usageLimit}
-                onClick={() => toggleSection('usageLimit')}
-              />
-            </motion.div>
+            <ExpandButton
+              isExpanded={expandedSections.usageLimit}
+              onClick={() => toggleSection('usageLimit')}
+            />
           )}
         </div>
       </div>
       {/* 이용방법 */}
       <div className="relative z-10">
         <div className="text-sm font-semibold text-gray-700 mb-2">이용방법</div>
-        <div className="text-xs text-gray-600 overflow-hidden">
-          <motion.div
-            layout
-            animate={{ 
-              height: expandedSections.usageMethod ? 'auto' : 'auto'
-            }}
-            transition={{
-              duration: 0.4,
-              ease: [0.25, 0.46, 0.45, 0.94]
-            }}
-          >
-            <motion.span 
-              className="break-words whitespace-pre-line block"
-              animate={{
-                opacity: 1
-              }}
-              transition={{
-                duration: 0.2,
-                delay: expandedSections.usageMethod ? 0 : 0.1
-              }}
-            >
-              {expandedSections.usageMethod 
-                ? usageMethod 
-                : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)
-              }
-            </motion.span>
-          </motion.div>
+        <div className="text-xs text-gray-600">
+          <span className="break-words whitespace-pre-line block">
+            {expandedSections.usageMethod 
+              ? usageMethod 
+              : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)
+            }
+          </span>
           {shouldShowExpand(usageMethod, TEXT_LIMITS.usageMethod) && (
-            <motion.div
-              initial={{ opacity: 0, y: -5 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, delay: 0.1 }}
-            >
-              <ExpandButton
-                isExpanded={expandedSections.usageMethod}
-                onClick={() => toggleSection('usageMethod')}
-              />
-            </motion.div>
+            <ExpandButton
+              isExpanded={expandedSections.usageMethod}
+              onClick={() => toggleSection('usageMethod')}
+            />
           )}
         </div>
       </div>

--- a/src/features/kakao-map/components/card/StoreDetailCard.tsx
+++ b/src/features/kakao-map/components/card/StoreDetailCard.tsx
@@ -47,18 +47,16 @@ const ExpandButton: React.FC<{
   </button>
 );
 
-// 애니메이션 변형
+// 개선된 애니메이션 변형
 const expandVariants = {
   collapsed: { 
-    height: 'auto',
     opacity: 1 
   },
   expanded: { 
-    height: 'auto',
     opacity: 1,
     transition: {
-      height: { duration: 0.3, ease: [0.04, 0.62, 0.23, 0.98] },
-      opacity: { duration: 0.2 }
+      duration: 0.3,
+      ease: [0.25, 0.46, 0.45, 0.94]
     }
   }
 };
@@ -157,26 +155,46 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
               <span>{userGrade}</span>
             </div>
             <div className="bg-yellow-50 px-3 py-1 rounded-tr rounded-br text-sm flex-1 min-w-0">
-              <motion.div 
-                layout
-                className="break-words text-left"
-                variants={expandVariants}
-                initial="collapsed"
-                animate={expandedSections.benefits ? "expanded" : "collapsed"}
-              >
-                <span className="whitespace-pre-wrap block">
-                  {expandedSections.benefits 
-                    ? benefits 
-                    : getTruncatedText(benefits, TEXT_LIMITS.benefits)
-                  }
-                </span>
+              <div className="break-words text-left overflow-hidden">
+                <motion.div
+                  layout
+                  animate={{ 
+                    height: expandedSections.benefits ? 'auto' : 'auto'
+                  }}
+                  transition={{
+                    duration: 0.4,
+                    ease: [0.25, 0.46, 0.45, 0.94]
+                  }}
+                >
+                  <motion.span 
+                    className="whitespace-pre-wrap block"
+                    animate={{
+                      opacity: 1
+                    }}
+                    transition={{
+                      duration: 0.2,
+                      delay: expandedSections.benefits ? 0 : 0.1
+                    }}
+                  >
+                    {expandedSections.benefits 
+                      ? benefits 
+                      : getTruncatedText(benefits, TEXT_LIMITS.benefits)
+                    }
+                  </motion.span>
+                </motion.div>
                 {shouldShowExpand(benefits, TEXT_LIMITS.benefits) && (
-                  <ExpandButton
-                    isExpanded={expandedSections.benefits}
-                    onClick={() => toggleSection('benefits')}
-                  />
+                  <motion.div
+                    initial={{ opacity: 0, y: -5 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.2, delay: 0.1 }}
+                  >
+                    <ExpandButton
+                      isExpanded={expandedSections.benefits}
+                      onClick={() => toggleSection('benefits')}
+                    />
+                  </motion.div>
                 )}
-              </motion.div>
+              </div>
             </div>
           </div>
         </div>
@@ -186,50 +204,90 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
         <div className="text-sm font-semibold text-gray-700 mb-2">
           제공 횟수
         </div>
-        <motion.div 
-          layout
-          className="text-sm"
-          variants={expandVariants}
-          initial="collapsed"
-          animate={expandedSections.usageLimit ? "expanded" : "collapsed"}
-        >
-          <span className="break-words whitespace-pre-wrap">
-            {expandedSections.usageLimit 
-              ? usageLimit 
-              : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)
-            }
-          </span>
+        <div className="text-sm overflow-hidden">
+          <motion.div
+            layout
+            animate={{ 
+              height: expandedSections.usageLimit ? 'auto' : 'auto'
+            }}
+            transition={{
+              duration: 0.4,
+              ease: [0.25, 0.46, 0.45, 0.94]
+            }}
+          >
+            <motion.span 
+              className="break-words whitespace-pre-wrap block"
+              animate={{
+                opacity: 1
+              }}
+              transition={{
+                duration: 0.2,
+                delay: expandedSections.usageLimit ? 0 : 0.1
+              }}
+            >
+              {expandedSections.usageLimit 
+                ? usageLimit 
+                : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)
+              }
+            </motion.span>
+          </motion.div>
           {shouldShowExpand(usageLimit, TEXT_LIMITS.usageLimit) && (
-            <ExpandButton
-              isExpanded={expandedSections.usageLimit}
-              onClick={() => toggleSection('usageLimit')}
-            />
+            <motion.div
+              initial={{ opacity: 0, y: -5 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, delay: 0.1 }}
+            >
+              <ExpandButton
+                isExpanded={expandedSections.usageLimit}
+                onClick={() => toggleSection('usageLimit')}
+              />
+            </motion.div>
           )}
-        </motion.div>
+        </div>
       </div>
       {/* 이용방법 */}
       <div className="relative z-10">
         <div className="text-sm font-semibold text-gray-700 mb-2">이용방법</div>
-        <motion.div 
-          layout
-          className="text-xs text-gray-600"
-          variants={expandVariants}
-          initial="collapsed"
-          animate={expandedSections.usageMethod ? "expanded" : "collapsed"}
-        >
-          <span className="break-words whitespace-pre-line">
-            {expandedSections.usageMethod 
-              ? usageMethod 
-              : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)
-            }
-          </span>
+        <div className="text-xs text-gray-600 overflow-hidden">
+          <motion.div
+            layout
+            animate={{ 
+              height: expandedSections.usageMethod ? 'auto' : 'auto'
+            }}
+            transition={{
+              duration: 0.4,
+              ease: [0.25, 0.46, 0.45, 0.94]
+            }}
+          >
+            <motion.span 
+              className="break-words whitespace-pre-line block"
+              animate={{
+                opacity: 1
+              }}
+              transition={{
+                duration: 0.2,
+                delay: expandedSections.usageMethod ? 0 : 0.1
+              }}
+            >
+              {expandedSections.usageMethod 
+                ? usageMethod 
+                : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)
+              }
+            </motion.span>
+          </motion.div>
           {shouldShowExpand(usageMethod, TEXT_LIMITS.usageMethod) && (
-            <ExpandButton
-              isExpanded={expandedSections.usageMethod}
-              onClick={() => toggleSection('usageMethod')}
-            />
+            <motion.div
+              initial={{ opacity: 0, y: -5 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, delay: 0.1 }}
+            >
+              <ExpandButton
+                isExpanded={expandedSections.usageMethod}
+                onClick={() => toggleSection('usageMethod')}
+              />
+            </motion.div>
           )}
-        </motion.div>
+        </div>
       </div>
     </div>
   );

--- a/src/features/kakao-map/components/card/StoreDetailCard.tsx
+++ b/src/features/kakao-map/components/card/StoreDetailCard.tsx
@@ -1,3 +1,6 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
 export interface StoreDetailCardProps {
   storeName: string;
   isFavorite: boolean;
@@ -9,6 +12,57 @@ export interface StoreDetailCardProps {
   handleToggleFavorite?: () => void;
 }
 
+// 텍스트 길이 제한 상수
+const TEXT_LIMITS = {
+  benefits: 50,
+  usageLimit: 30,
+  usageMethod: 40,
+};
+
+// 텍스트가 제한을 초과하는지 확인하는 헬퍼 함수
+const shouldShowExpand = (text: string, limit: number): boolean => {
+  return text.length > limit;
+};
+
+// 축약된 텍스트를 반환하는 헬퍼 함수
+const getTruncatedText = (text: string, limit: number): string => {
+  if (text.length <= limit) return text;
+  return text.substring(0, limit) + '...';
+};
+
+// 더보기 버튼 컴포넌트
+const ExpandButton: React.FC<{
+  isExpanded: boolean;
+  onClick: () => void;
+}> = ({ isExpanded, onClick }) => (
+  <button
+    onClick={(e) => {
+      e.stopPropagation();
+      onClick();
+    }}
+    className="inline text-blue-500 hover:text-blue-700 font-medium text-xs ml-1 transition-colors duration-200"
+    aria-label={isExpanded ? '접기' : '더보기'}
+  >
+    {isExpanded ? '접기' : '더보기'}
+  </button>
+);
+
+// 애니메이션 변형
+const expandVariants = {
+  collapsed: { 
+    height: 'auto',
+    opacity: 1 
+  },
+  expanded: { 
+    height: 'auto',
+    opacity: 1,
+    transition: {
+      height: { duration: 0.3, ease: [0.04, 0.62, 0.23, 0.98] },
+      opacity: { duration: 0.2 }
+    }
+  }
+};
+
 const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
   storeName,
   isFavorite,
@@ -19,6 +73,20 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
   userGrade = '우수', // 기본값 설정
   handleToggleFavorite,
 }) => {
+  // 각 섹션의 확장 상태 관리
+  const [expandedSections, setExpandedSections] = useState({
+    benefits: false,
+    usageLimit: false,
+    usageMethod: false,
+  });
+
+  // 섹션 확장/축소 토글 함수
+  const toggleSection = (section: keyof typeof expandedSections) => {
+    setExpandedSections(prev => ({
+      ...prev,
+      [section]: !prev[section],
+    }));
+  };
   return (
     <div className="relative w-[20rem] bg-white rounded-2xl shadow-lg p-6 pt-5 pb-8">
       {/* 말풍선 꼬리 */}
@@ -89,9 +157,26 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
               <span>{userGrade}</span>
             </div>
             <div className="bg-yellow-50 px-3 py-1 rounded-tr rounded-br text-sm flex-1 min-w-0">
-              <span className="break-words whitespace-pre-wrap text-left block">
-                {benefits}
-              </span>
+              <motion.div 
+                layout
+                className="break-words text-left"
+                variants={expandVariants}
+                initial="collapsed"
+                animate={expandedSections.benefits ? "expanded" : "collapsed"}
+              >
+                <span className="whitespace-pre-wrap block">
+                  {expandedSections.benefits 
+                    ? benefits 
+                    : getTruncatedText(benefits, TEXT_LIMITS.benefits)
+                  }
+                </span>
+                {shouldShowExpand(benefits, TEXT_LIMITS.benefits) && (
+                  <ExpandButton
+                    isExpanded={expandedSections.benefits}
+                    onClick={() => toggleSection('benefits')}
+                  />
+                )}
+              </motion.div>
             </div>
           </div>
         </div>
@@ -101,14 +186,50 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
         <div className="text-sm font-semibold text-gray-700 mb-2">
           제공 횟수
         </div>
-        <div className="text-sm">{usageLimit}</div>
+        <motion.div 
+          layout
+          className="text-sm"
+          variants={expandVariants}
+          initial="collapsed"
+          animate={expandedSections.usageLimit ? "expanded" : "collapsed"}
+        >
+          <span className="break-words whitespace-pre-wrap">
+            {expandedSections.usageLimit 
+              ? usageLimit 
+              : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)
+            }
+          </span>
+          {shouldShowExpand(usageLimit, TEXT_LIMITS.usageLimit) && (
+            <ExpandButton
+              isExpanded={expandedSections.usageLimit}
+              onClick={() => toggleSection('usageLimit')}
+            />
+          )}
+        </motion.div>
       </div>
       {/* 이용방법 */}
       <div className="relative z-10">
         <div className="text-sm font-semibold text-gray-700 mb-2">이용방법</div>
-        <div className="text-xs text-gray-600 whitespace-pre-line">
-          {usageMethod}
-        </div>
+        <motion.div 
+          layout
+          className="text-xs text-gray-600"
+          variants={expandVariants}
+          initial="collapsed"
+          animate={expandedSections.usageMethod ? "expanded" : "collapsed"}
+        >
+          <span className="break-words whitespace-pre-line">
+            {expandedSections.usageMethod 
+              ? usageMethod 
+              : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)
+            }
+          </span>
+          {shouldShowExpand(usageMethod, TEXT_LIMITS.usageMethod) && (
+            <ExpandButton
+              isExpanded={expandedSections.usageMethod}
+              onClick={() => toggleSection('usageMethod')}
+            />
+          )}
+        </motion.div>
       </div>
     </div>
   );

--- a/src/features/kakao-map/components/card/StoreDetailCard.tsx
+++ b/src/features/kakao-map/components/card/StoreDetailCard.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
 
 export interface StoreDetailCardProps {
   storeName: string;
@@ -36,7 +35,7 @@ const ExpandButton: React.FC<{
   onClick: () => void;
 }> = ({ isExpanded, onClick }) => (
   <button
-    onClick={(e) => {
+    onClick={e => {
       e.stopPropagation();
       onClick();
     }}
@@ -46,7 +45,6 @@ const ExpandButton: React.FC<{
     {isExpanded ? '접기' : '더보기'}
   </button>
 );
-
 
 const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
   storeName,
@@ -144,10 +142,9 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
             <div className="bg-yellow-50 px-3 py-1 rounded-tr rounded-br text-sm flex-1 min-w-0">
               <div className="break-words text-left">
                 <span className="whitespace-pre-wrap block">
-                  {expandedSections.benefits 
-                    ? benefits 
-                    : getTruncatedText(benefits, TEXT_LIMITS.benefits)
-                  }
+                  {expandedSections.benefits
+                    ? benefits
+                    : getTruncatedText(benefits, TEXT_LIMITS.benefits)}
                 </span>
                 {shouldShowExpand(benefits, TEXT_LIMITS.benefits) && (
                   <ExpandButton
@@ -167,10 +164,9 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
         </div>
         <div className="text-sm">
           <span className="break-words whitespace-pre-wrap block">
-            {expandedSections.usageLimit 
-              ? usageLimit 
-              : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)
-            }
+            {expandedSections.usageLimit
+              ? usageLimit
+              : getTruncatedText(usageLimit, TEXT_LIMITS.usageLimit)}
           </span>
           {shouldShowExpand(usageLimit, TEXT_LIMITS.usageLimit) && (
             <ExpandButton
@@ -185,10 +181,9 @@ const StoreDetailCard: React.FC<StoreDetailCardProps> = ({
         <div className="text-sm font-semibold text-gray-700 mb-2">이용방법</div>
         <div className="text-xs text-gray-600">
           <span className="break-words whitespace-pre-line block">
-            {expandedSections.usageMethod 
-              ? usageMethod 
-              : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)
-            }
+            {expandedSections.usageMethod
+              ? usageMethod
+              : getTruncatedText(usageMethod, TEXT_LIMITS.usageMethod)}
           </span>
           {shouldShowExpand(usageMethod, TEXT_LIMITS.usageMethod) && (
             <ExpandButton

--- a/src/features/kakao-map/components/marker/BrandMarker.tsx
+++ b/src/features/kakao-map/components/marker/BrandMarker.tsx
@@ -1,18 +1,17 @@
 import { type FC } from 'react';
+
 import { CATEGORY_CONFIGS } from '../../types/category.ts';
 import type { Store } from '../../types/store.ts';
 
 interface BrandMarkerProps {
   store: Store;
   isSelected?: boolean;
-  hasPromotion?: boolean;
   onClick?: () => void;
 }
 
 const BrandMarker: FC<BrandMarkerProps> = ({
   store,
   isSelected = false,
-  hasPromotion = false,
   onClick,
 }) => {
   const category = store.categoryName as keyof typeof CATEGORY_CONFIGS;
@@ -21,13 +20,6 @@ const BrandMarker: FC<BrandMarkerProps> = ({
 
   return (
     <div className="relative" onClick={onClick}>
-      {/* 프로모션 배지 */}
-      {hasPromotion && (
-        <div className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 rounded-full flex items-center justify-center z-10">
-          <span className="text-white text-xs font-bold">!</span>
-        </div>
-      )}
-
       {/* 메인 마커 */}
       <div
         className={`

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -268,7 +268,6 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
             <BrandMarker
               store={store}
               isSelected={selectedStoreId === store.storeId}
-              hasPromotion={!!store.benefit}
               onClick={() => handleMarkerClick(store)}
             />
           </CustomOverlayMap>

--- a/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
+++ b/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-
 import AddStore from '@mymap/components/mymap-add-store/AddStore';
+import { motion } from 'framer-motion';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
 
 import { useModalStore } from '@/shared/store';
@@ -13,6 +12,107 @@ interface StoreInfoWindowProps {
   position: { lat: number; lng: number };
   handleToggleFavorite?: () => void;
 }
+
+// 고급 버블 애니메이션 설정
+const bubbleVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.3,
+    y: 40,
+    rotateX: -15,
+    transformOrigin: 'center bottom',
+  },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    y: 0,
+    rotateX: 0,
+    transformOrigin: 'center bottom',
+    transition: {
+      type: 'spring' as const,
+      stiffness: 400,
+      damping: 15,
+      mass: 0.8,
+      velocity: 2,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.8,
+    y: -20,
+    rotateX: 10,
+    transition: {
+      duration: 0.3,
+      ease: [0.4, 0, 0.2, 1] as const,
+    },
+  },
+};
+
+// 그림자 효과 애니메이션
+const shadowVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.8,
+    y: 10,
+  },
+  visible: {
+    opacity: [0, 0.3, 0.2],
+    scale: [0.8, 1.2, 1],
+    y: [10, 0, 0],
+    transition: {
+      duration: 0.6,
+      times: [0, 0.3, 1],
+      ease: 'easeOut' as const,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.9,
+    transition: {
+      duration: 0.2,
+    },
+  },
+};
+
+// 내용 요소들의 스태거 애니메이션
+const contentVariants = {
+  hidden: {
+    opacity: 0,
+    y: 20,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: 0.2,
+      duration: 0.4,
+      ease: [0.04, 0.62, 0.23, 0.98] as const,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: -10,
+    transition: {
+      duration: 0.2,
+    },
+  },
+};
+
+// 로딩 상태 애니메이션
+const loadingVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.9,
+  },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: {
+      duration: 0.3,
+      ease: [0.04, 0.62, 0.23, 0.98] as const,
+    },
+  },
+};
 
 const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
   storeId,
@@ -40,9 +140,25 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
         xAnchor={0.5}
         zIndex={1000}
       >
-        <div className="bg-white p-4 rounded-lg shadow-lg relative z-50">
-          <div className="animate-pulse">로딩 중...</div>
-        </div>
+        <motion.div
+          className="bg-white p-4 rounded-lg shadow-lg relative z-50"
+          variants={loadingVariants}
+          initial="hidden"
+          animate="visible"
+        >
+          <div className="animate-pulse flex items-center space-x-2">
+            <div className="w-4 h-4 bg-gray-300 rounded-full animate-bounce"></div>
+            <div
+              className="w-4 h-4 bg-gray-300 rounded-full animate-bounce"
+              style={{ animationDelay: '0.1s' }}
+            ></div>
+            <div
+              className="w-4 h-4 bg-gray-300 rounded-full animate-bounce"
+              style={{ animationDelay: '0.2s' }}
+            ></div>
+            <span className="text-gray-500 text-sm">로딩 중...</span>
+          </div>
+        </motion.div>
       </CustomOverlayMap>
     );
   }
@@ -60,27 +176,77 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
       xAnchor={0.5}
       zIndex={1000}
     >
-      <div
-        className="relative z-50"
-        onClick={e => {
-          e.stopPropagation();
-        }}
-        onMouseDown={e => {
-          e.stopPropagation();
-        }}
-        onMouseUp={e => {
-          e.stopPropagation();
-        }}
-      >
-        <StoreDetailCard
-          storeName={storeDetail.storeName}
-          isFavorite={storeDetail.isFavorite}
-          favoriteCount={storeDetail.favoriteCount}
-          benefits={storeDetail.benefits}
-          usageLimit={storeDetail.usageLimit}
-          usageMethod={storeDetail.usageMethod}
-          handleToggleFavorite={handleFavoriteClick}
+      <div className="relative perspective-1000">
+        {/* 그림자 효과 */}
+        <motion.div
+          className="absolute inset-0 bg-black/10 rounded-2xl blur-lg"
+          variants={shadowVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          style={{
+            transform: 'translateZ(-10px)',
+          }}
         />
+
+        {/* 메인 버블 컨테이너 */}
+        <motion.div
+          className="relative z-50"
+          variants={bubbleVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          onClick={e => {
+            e.stopPropagation();
+          }}
+          onMouseDown={e => {
+            e.stopPropagation();
+          }}
+          onMouseUp={e => {
+            e.stopPropagation();
+          }}
+          style={{
+            filter: 'drop-shadow(0 10px 25px rgba(0, 0, 0, 0.15))',
+          }}
+        >
+          {/* 내용 컨테이너 */}
+          <motion.div
+            variants={contentVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+          >
+            <StoreDetailCard
+              storeName={storeDetail.storeName}
+              isFavorite={storeDetail.isFavorite}
+              favoriteCount={storeDetail.favoriteCount}
+              benefits={storeDetail.benefits}
+              usageLimit={storeDetail.usageLimit}
+              usageMethod={storeDetail.usageMethod}
+              handleToggleFavorite={handleFavoriteClick}
+            />
+          </motion.div>
+
+          {/* 글로우 효과 */}
+          <motion.div
+            className="absolute inset-0 rounded-2xl opacity-30"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{
+              opacity: [0, 0.3, 0.1, 0],
+              scale: [0.8, 1.1, 1.05, 1],
+            }}
+            transition={{
+              duration: 0.8,
+              times: [0, 0.3, 0.7, 1],
+              ease: 'easeOut',
+            }}
+            style={{
+              background:
+                'radial-gradient(circle, rgba(59, 130, 246, 0.1) 0%, transparent 70%)',
+              pointerEvents: 'none',
+            }}
+          />
+        </motion.div>
       </div>
     </CustomOverlayMap>
   );

--- a/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
+++ b/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
@@ -48,26 +48,80 @@ const bubbleVariants = {
   },
 };
 
-// 그림자 효과 애니메이션
-const shadowVariants = {
+// 다층 그림자 효과 애니메이션
+const baseShadowVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.7,
+    y: 15,
+  },
+  visible: {
+    opacity: 0.12,
+    scale: 1.1,
+    y: 8,
+    transition: {
+      duration: 0.5,
+      ease: [0.25, 0.46, 0.45, 0.94] as const,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.8,
+    y: 5,
+    transition: {
+      duration: 0.3,
+    },
+  },
+};
+
+// 주요 그림자 효과
+const mainShadowVariants = {
   hidden: {
     opacity: 0,
     scale: 0.8,
-    y: 10,
+    y: 12,
   },
   visible: {
-    opacity: [0, 0.3, 0.2],
-    scale: [0.8, 1.2, 1],
-    y: [10, 0, 0],
+    opacity: 0.25,
+    scale: 1.05,
+    y: 6,
     transition: {
-      duration: 0.6,
-      times: [0, 0.3, 1],
-      ease: 'easeOut' as const,
+      duration: 0.4,
+      delay: 0.1,
+      ease: [0.25, 0.46, 0.45, 0.94] as const,
     },
   },
   exit: {
     opacity: 0,
     scale: 0.9,
+    y: 3,
+    transition: {
+      duration: 0.25,
+    },
+  },
+};
+
+// 가까운 그림자 효과
+const nearShadowVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.9,
+    y: 8,
+  },
+  visible: {
+    opacity: 0.15,
+    scale: 1.02,
+    y: 2,
+    transition: {
+      duration: 0.3,
+      delay: 0.15,
+      ease: [0.25, 0.46, 0.45, 0.94] as const,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.95,
+    y: 1,
     transition: {
       duration: 0.2,
     },
@@ -97,6 +151,7 @@ const contentVariants = {
     },
   },
 };
+
 
 // 로딩 상태 애니메이션
 const loadingVariants = {
@@ -172,19 +227,52 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
   return (
     <CustomOverlayMap
       position={position}
-      yAnchor={1.25}
+      yAnchor={1.12}
       xAnchor={0.5}
       zIndex={1000}
     >
-      <div className="relative perspective-1000">
-        {/* 그림자 효과 */}
+      <div className="relative perspective-1000" style={{ padding: '20px' }}>
+        {/* 베이스 그림자 (가장 넓고 흐린 그림자) */}
         <motion.div
-          className="absolute inset-0 bg-black/10 rounded-2xl blur-lg"
-          variants={shadowVariants}
+          className="absolute inset-0 rounded-2xl"
+          variants={baseShadowVariants}
           initial="hidden"
           animate="visible"
           exit="exit"
           style={{
+            background:
+              'radial-gradient(ellipse 120% 60% at center, rgba(0, 0, 0, 0.08) 0%, transparent 60%)',
+            filter: 'blur(20px)',
+            transform: 'translateZ(-30px)',
+          }}
+        />
+
+        {/* 메인 그림자 (중간 깊이) */}
+        <motion.div
+          className="absolute inset-0 rounded-2xl"
+          variants={mainShadowVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          style={{
+            background:
+              'radial-gradient(ellipse 100% 50% at center, rgba(0, 0, 0, 0.12) 0%, transparent 70%)',
+            filter: 'blur(12px)',
+            transform: 'translateZ(-20px)',
+          }}
+        />
+
+        {/* 가까운 그림자 (선명한 그림자) */}
+        <motion.div
+          className="absolute inset-0 rounded-2xl"
+          variants={nearShadowVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          style={{
+            background:
+              'radial-gradient(ellipse 90% 40% at center, rgba(0, 0, 0, 0.15) 0%, transparent 80%)',
+            filter: 'blur(6px)',
             transform: 'translateZ(-10px)',
           }}
         />
@@ -205,8 +293,13 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
           onMouseUp={e => {
             e.stopPropagation();
           }}
+          whileHover={{
+            y: -2,
+            transition: { duration: 0.2, ease: 'easeOut' },
+          }}
           style={{
-            filter: 'drop-shadow(0 10px 25px rgba(0, 0, 0, 0.15))',
+            filter:
+              'drop-shadow(0 4px 12px rgba(0, 0, 0, 0.1)) drop-shadow(0 20px 40px rgba(0, 0, 0, 0.08))',
           }}
         >
           {/* 내용 컨테이너 */}
@@ -215,6 +308,10 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
             initial="hidden"
             animate="visible"
             exit="exit"
+            className="bg-white rounded-2xl overflow-hidden"
+            style={{
+              boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.6)',
+            }}
           >
             <StoreDetailCard
               storeName={storeDetail.storeName}
@@ -229,23 +326,55 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
 
           {/* 글로우 효과 */}
           <motion.div
-            className="absolute inset-0 rounded-2xl opacity-30"
+            className="absolute inset-0 rounded-2xl opacity-20"
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{
-              opacity: [0, 0.3, 0.1, 0],
+              opacity: [0, 0.2, 0.05, 0],
               scale: [0.8, 1.1, 1.05, 1],
             }}
             transition={{
-              duration: 0.8,
-              times: [0, 0.3, 0.7, 1],
+              duration: 1.2,
+              times: [0, 0.25, 0.8, 1],
               ease: 'easeOut',
             }}
             style={{
               background:
-                'radial-gradient(circle, rgba(59, 130, 246, 0.1) 0%, transparent 70%)',
+                'conic-gradient(from 0deg, rgba(59, 130, 246, 0.1) 0%, rgba(147, 51, 234, 0.05) 120deg, rgba(59, 130, 246, 0.1) 240deg, rgba(59, 130, 246, 0.1) 360deg)',
               pointerEvents: 'none',
             }}
           />
+
+          {/* 하이라이트 효과 */}
+          <motion.div
+            className="absolute top-0 left-1/4 right-1/4 h-px rounded-full"
+            initial={{ opacity: 0, scaleX: 0 }}
+            animate={{
+              opacity: [0, 0.6, 0],
+              scaleX: [0, 1, 1],
+            }}
+            transition={{
+              duration: 0.8,
+              times: [0, 0.3, 1],
+              delay: 0.4,
+            }}
+            style={{
+              background:
+                'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.8), transparent)',
+              pointerEvents: 'none',
+            }}
+          />
+
+          {/* 삼각형 꼬리 */}
+          <div className="absolute left-1/2 -bottom-4 -translate-x-1/2 w-8 h-8 z-0">
+            <svg width="32" height="32" viewBox="0 0 32 32">
+              <polygon
+                points="16,32 0,0 32,0"
+                fill="white"
+                stroke="rgba(226, 232, 240, 0.4)"
+                strokeWidth="0.5"
+              />
+            </svg>
+          </div>
         </motion.div>
       </div>
     </CustomOverlayMap>

--- a/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
+++ b/src/features/kakao-map/components/marker/StoreInfoWindow.tsx
@@ -152,6 +152,38 @@ const contentVariants = {
   },
 };
 
+// 꼬리 애니메이션
+const tailVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.3,
+    y: -15,
+    rotateX: -30,
+  },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    y: 0,
+    rotateX: 0,
+    transition: {
+      delay: 0.15,
+      type: 'spring' as const,
+      stiffness: 400,
+      damping: 20,
+      mass: 0.8,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.8,
+    y: -10,
+    rotateX: 15,
+    transition: {
+      duration: 0.2,
+      ease: [0.4, 0, 0.2, 1] as const,
+    },
+  },
+};
 
 // 로딩 상태 애니메이션
 const loadingVariants = {
@@ -365,7 +397,16 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
           />
 
           {/* 삼각형 꼬리 */}
-          <div className="absolute left-1/2 -bottom-4 -translate-x-1/2 w-8 h-8 z-0">
+          <motion.div
+            className="absolute left-1/2 -bottom-4 -translate-x-1/2 w-8 h-8 z-0"
+            variants={tailVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            style={{
+              transformOrigin: 'center top',
+            }}
+          >
             <svg width="32" height="32" viewBox="0 0 32 32">
               <polygon
                 points="16,32 0,0 32,0"
@@ -374,7 +415,7 @@ const StoreInfoWindow: React.FC<StoreInfoWindowProps> = ({
                 strokeWidth="0.5"
               />
             </svg>
-          </div>
+          </motion.div>
         </motion.div>
       </div>
     </CustomOverlayMap>


### PR DESCRIPTION
[![UHYU-279](https://badgen.net/badge/JIRA/UHYU-279/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-279) ![Medium](https://badgen.net/badge/PR%20Size/Medium/yellow) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-279-info-window)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-279-info-window) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 현재 UI 캡처

1. 실제 긴 텍스트 응답값을 처리하여 긴글일 때 더보기 로직 도입
2. framer 기반 애니메이션 도입으로 인포 윈도우 나올 때 애니메이션 도입


|더보기 로직 및 인포윈도우 애니메이션|
|:--:|
|![인포윈도우_애니메이션](https://github.com/user-attachments/assets/d8b3984c-0ae4-4944-8d87-961c9c90b72c)|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-279]: https://u-hyu.atlassian.net/browse/UHYU-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 상세 정보 카드에서 혜택, 이용 제한, 이용 방법 항목에 대해 텍스트 펼치기/접기 기능이 추가되었습니다.

* **개선 사항**
  * 매장 상세 정보의 혜택, 이용 제한, 이용 방법 설명이 더욱 구체적이고 상세하게 업데이트되었습니다.
  * 매장 정보 창에 다양한 애니메이션 효과가 적용되어 더욱 생동감 있는 UI를 경험할 수 있습니다.

* **기능 변경**
  * 매장 마커에서 프로모션 뱃지(느낌표)가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->