### PR TITLE
[FIX][UHYU-300] 유효한 토큰 상태에서도 강제 로그아웃 UI 적용되는 문제 해결

### DIFF
--- a/src/features/user/api/userApi.ts
+++ b/src/features/user/api/userApi.ts
@@ -38,11 +38,11 @@ export const userApi = {
   },
 
   // 유저 정보 조회
-  getUserInfo: async (): Promise<UserInfomation> => {
+  getUserInfo: async (): Promise<ApiResponse<UserInfomation>> => {
     const res = await client.get<ApiResponse<UserInfomation>>(
       USER_ENDPOINTS.USER.ROOT
     );
-    return res.data.data!;
+    return res.data;
   },
 
   // 로그아웃

--- a/src/shared/store/userStore.ts
+++ b/src/shared/store/userStore.ts
@@ -1,7 +1,9 @@
 import { userApi } from '@user/index';
+import type { AxiosError } from 'axios';
 import { toast } from 'sonner';
 import { create } from 'zustand';
 
+import type { ApiError } from '@/shared/client/client.type';
 import type { SimpleUserInfo } from '@/shared/types';
 
 interface UserState {
@@ -33,22 +35,24 @@ export const userStore = create<UserState>(set => ({
       if (import.meta.env.DEV) {
         console.log('🔄 유저 정보 조회 시작...');
       }
+
       const res = await userApi.getUserInfo();
-      if (import.meta.env.DEV) {
-        console.log('✅ 유저 정보 조회 성공:', res);
+
+      if (res.statusCode === 200 && res.data) {
+        const { userName, grade, profileImage, role } = res.data;
+        userStore.getState().setUser({ userName, grade, profileImage, role });
+      } else {
+        console.warn('⚠️ 유저 정보 조회 실패: 응답 데이터 없음', res);
+        userStore.getState().clearUser();
       }
-      const { userName, grade, profileImage, role } = res;
-      const userInfo = { userName, grade, profileImage, role };
-      if (import.meta.env.DEV) {
-        console.log('📝 유저 정보 저장:', userInfo);
+    } catch (error: unknown) {
+      const err = error as AxiosError<ApiError>;
+      // 401이면 clearUser(), 그 외 에러는 유지
+      if (err.response?.data?.statusCode === 401) {
+        userStore.getState().clearUser();
+      } else {
+        console.warn('⚠️ 유저 정보 조회 실패(비401): 상태 유지', err);
       }
-      userStore.getState().setUser(userInfo); // 성공 시 저장
-    } catch (error) {
-      console.warn('⚠️ 유저 정보 불러오기 실패:', error);
-      if (import.meta.env.DEV) {
-        console.error('❌ Error details:', error);
-      }
-      userStore.getState().clearUser(); // 실패 시 초기화
     }
   },
 }));


### PR DESCRIPTION
[![UHYU-300](https://badgen.net/badge/JIRA/UHYU-300/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-300) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-300-login-modal-fix)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-300-login-modal-fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
토큰이 유효하지만 userStore가 clear 되어서 모달이 뜨는 문제 해결

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-300]: https://u-hyu.atlassian.net/browse/UHYU-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 정보 조회 시 응답 구조 변경에 따라 사용자 상태를 더 정확하게 처리합니다.
  * 인증 오류(401) 발생 시에만 사용자 상태를 초기화하고, 기타 오류 발생 시에는 기존 사용자 정보를 유지하도록 개선되었습니다.
  * 오류 및 응답 데이터 검증 로직이 강화되어 예외 상황에서도 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->