### PR TITLE
[FEAT][UHYU-307] 공유 지도(/map/:uuid)에서 검색창 및 필터 숨김 처리

### DIFF
--- a/src/features/kakao-map/components/MapControlsContainer.tsx
+++ b/src/features/kakao-map/components/MapControlsContainer.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
+import { useParams } from 'react-router-dom';
+
 import { getKakaoApiKeyStatus } from '../api/keywordSearchApi';
 import type { NormalizedPlace } from '../api/types';
 import { useMapUIContext } from '../context/MapUIContext';
@@ -246,7 +248,10 @@ export const MapControlsContainer: React.FC<MapControlsContainerProps> = ({
     }
   };
 
-  return (
+  const { uuid } = useParams();
+  const isShared = !!uuid;
+
+  return isShared ? null : (
     <MapTopControls
       searchValue={searchValue}
       onSearchValueChange={handleSearchValueChange}


### PR DESCRIPTION
[![UHYU-307](https://badgen.net/badge/JIRA/UHYU-307/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-307) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-307-mymap-delete)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-307-mymap-delete) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
- MapControlsContainer.tsx에 useParams를 사용하여 uuid 유무 판단

- 공유 지도(uuid 존재)일 경우 MapTopControls 렌더링되지 않도록 조건부 처리

# 현재 UI 캡처

|공유 지도|
|:--:|
|<img width="301" height="660" alt="스크린샷 2025-07-30 오후 4 03 07" src="https://github.com/user-attachments/assets/9d409261-b751-4442-8bf6-2083f759e992" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-307]: https://u-hyu.atlassian.net/browse/UHYU-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * URL에 `uuid` 파라미터가 포함된 경우 지도 상단 컨트롤이 표시되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->