### PR TITLE
[FEAT][UHYU-262] 온보딩 페이지 완성 및 요청 정보 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <link
       rel="apple-touch-icon"
       sizes="57x57"

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width"
     />
     <link
       rel="apple-touch-icon"

--- a/src/features/admin/components/brand/AdminBrandForm.tsx
+++ b/src/features/admin/components/brand/AdminBrandForm.tsx
@@ -134,7 +134,7 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
           type="text"
           value={formData.brandName}
           onChange={(e) => handleInputChange('brandName', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+          className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
           placeholder="브랜드명을 입력하세요"
           required
         />
@@ -149,7 +149,7 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
           type="url"
           value={formData.brandImg}
           onChange={(e) => handleInputChange('brandImg', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+          className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
           placeholder="https://example.com/logo.png"
           required
         />
@@ -163,7 +163,7 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
         <select
           value={formData.categoryId}
           onChange={(e) => handleInputChange('categoryId', Number(e.target.value))}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+          className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
           required
         >
           {categoryList.map((category: { categoryId: number; categoryName: string }) => (
@@ -183,7 +183,7 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
           type="text"
           value={formData.usageLimit}
           onChange={(e) => handleInputChange('usageLimit', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+          className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
           placeholder="예: 월 2회, 일 1회"
           required
         />
@@ -198,7 +198,7 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
           type="text"
           value={formData.usageMethod}
           onChange={(e) => handleInputChange('usageMethod', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+          className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
           placeholder="예: 카드 제시, 앱 바코드"
           required
         />
@@ -238,7 +238,7 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
                   type="text"
                   value={benefit.grade}
                   onChange={(e) => handleBenefitChange(index, 'grade', e.target.value)}
-                  className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
                   placeholder="등급 (예: GOOD, VIP, VVIP)"
                   required
                 />
@@ -246,14 +246,14 @@ export const AdminBrandForm = ({ brand, onSuccess }: AdminBrandFormProps) => {
                   type="text"
                   value={benefit.description}
                   onChange={(e) => handleBenefitChange(index, 'description', e.target.value)}
-                  className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
                   placeholder="혜택 설명 (예: 10% 할인)"
                   required
                 />
                 <select
                   value={benefit.benefitType}
                   onChange={(e) => handleBenefitChange(index, 'benefitType', e.target.value as 'DISCOUNT' | 'GIFT')}
-                  className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
                   required
                 >
                   <option value="DISCOUNT">할인</option>

--- a/src/features/admin/components/brand/BrandForm.tsx
+++ b/src/features/admin/components/brand/BrandForm.tsx
@@ -138,7 +138,7 @@ export const BrandForm = ({ brand, onSuccess, onCancel }: BrandFormProps) => {
               onChange={(e) => setFormData(prev => ({ ...prev, brandName: e.target.value }))}
               placeholder="브랜드명을 입력하세요"
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+              className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
             />
           </div>
 
@@ -151,7 +151,7 @@ export const BrandForm = ({ brand, onSuccess, onCancel }: BrandFormProps) => {
               value={formData.categoryId}
               onChange={(e) => setFormData(prev => ({ ...prev, categoryId: Number(e.target.value) }))}
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+              className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
             >
               {ADMIN_CATEGORIES.map(category => (
                 <option key={category.id} value={category.id}>
@@ -210,7 +210,7 @@ export const BrandForm = ({ brand, onSuccess, onCancel }: BrandFormProps) => {
               onChange={(e) => setFormData(prev => ({ ...prev, usageLimit: e.target.value }))}
               placeholder="예: 월 2회"
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+              className="w-full px-3 py-2 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
             />
           </div>
 

--- a/src/features/admin/components/brand/NewAdminBrandList.tsx
+++ b/src/features/admin/components/brand/NewAdminBrandList.tsx
@@ -142,7 +142,7 @@ export const NewAdminBrandList = () => {
           value={searchTerm}
           onChange={e => handleSearchChange(e.target.value)}
           placeholder="브랜드명으로 검색..."
-          className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+          className="w-full pl-10 pr-4 py-3 text-base md:text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
         />
       </div>
 

--- a/src/features/extra-info/components/ActionButtons.tsx
+++ b/src/features/extra-info/components/ActionButtons.tsx
@@ -61,13 +61,6 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
           )}
         </PrimaryButton>
       </div>
-
-      {/* 마지막 단계에서 제출 중일 때 추가 안내 */}
-      {isSubmitting && isLastStep && (
-        <p className="text-xs text-gray-500 text-center mt-2">
-          잠시만 기다려 주세요. 회원가입을 처리하고 있습니다.
-        </p>
-      )}
     </div>
   );
 };

--- a/src/features/extra-info/components/ActionButtons.tsx
+++ b/src/features/extra-info/components/ActionButtons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ChevronLeft, Loader2 } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
+import { BeatLoader } from 'react-spinners';
 
 import { GhostButton } from '@/shared/components';
 
@@ -51,8 +52,8 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
           className="flex-1 relative"
         >
           {isSubmitting && isLastStep ? (
-            <div className="flex items-center justify-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin" />
+            <div className="flex items-center justify-center gap-3">
+              <BeatLoader color="#ffffff" size={8} speedMultiplier={0.8} />
               <span>회원가입 중...</span>
             </div>
           ) : (

--- a/src/features/extra-info/components/CurrentStep.tsx
+++ b/src/features/extra-info/components/CurrentStep.tsx
@@ -160,34 +160,6 @@ export const CurrentStep: React.FC<EnhancedCurrentStepProps> = ({
                 submitError={submitError}
               />
             </motion.div>
-
-            {/* 제출 중 추가 안내 메시지 */}
-            {isSubmitting && currentStep === 4 && (
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
-                className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-center"
-              >
-                <div className="flex items-center justify-center gap-2 text-blue-700">
-                  <motion.div
-                    animate={{ rotate: 360 }}
-                    transition={{
-                      duration: 1,
-                      repeat: Infinity,
-                      ease: 'linear',
-                    }}
-                  >
-                    <RefreshCw className="w-4 h-4" />
-                  </motion.div>
-                  <span className="text-sm font-medium">
-                    회원가입 정보를 처리하고 있습니다...
-                  </span>
-                </div>
-                <p className="text-xs text-blue-600 mt-2">
-                  잠시만 기다려 주세요. 페이지를 닫지 마세요.
-                </p>
-              </motion.div>
-            )}
           </motion.div>
         ) : (
           renderCompletionState()

--- a/src/features/extra-info/components/CurrentStep.tsx
+++ b/src/features/extra-info/components/CurrentStep.tsx
@@ -15,7 +15,6 @@ import { type CurrentStepProps } from '../types';
 interface EnhancedCurrentStepProps extends CurrentStepProps {
   isSubmitting?: boolean;
   submitError?: Error | null;
-  submitSuccess?: boolean;
 }
 
 export const CurrentStep: React.FC<EnhancedCurrentStepProps> = ({

--- a/src/features/extra-info/components/CurrentStep.tsx
+++ b/src/features/extra-info/components/CurrentStep.tsx
@@ -123,7 +123,7 @@ export const CurrentStep: React.FC<EnhancedCurrentStepProps> = ({
   };
 
   return (
-    <div className="sticky top-0 bg-white z-10 px-6 py-8">
+    <div className="bg-white z-10 px-6 py-8">
       <AnimatePresence mode="wait">
         {currentStep <= 4 ? (
           <motion.div
@@ -151,14 +151,16 @@ export const CurrentStep: React.FC<EnhancedCurrentStepProps> = ({
               transition={{ duration: 0.3, delay: 0.2 }}
               className="pt-4"
             >
-              <ActionButtons
-                currentStep={currentStep}
-                isStepValid={isStepValid}
-                onNext={onNext}
-                onPrev={onPrev}
-                isSubmitting={isSubmitting}
-                submitError={submitError}
-              />
+              <div className="bottom-0 left-0 w-full bg-white px-6 py-4 z-50">
+                <ActionButtons
+                  currentStep={currentStep}
+                  isStepValid={isStepValid}
+                  onNext={onNext}
+                  onPrev={onPrev}
+                  isSubmitting={isSubmitting}
+                  submitError={submitError}
+                />
+              </div>
             </motion.div>
           </motion.div>
         ) : (

--- a/src/features/extra-info/components/StepContent.tsx
+++ b/src/features/extra-info/components/StepContent.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { BrandGrid, SelectionBottomSheet } from '@/shared/components';
+import { ApiBrandGrid, SelectionBottomSheet } from '@/shared/components';
 import { Label } from '@/shared/components/shadcn/ui/label';
 import {
   Select,
@@ -165,7 +165,7 @@ export const StepContent: React.FC<StepContentProps> = ({
 
     case 3:
       return (
-        <BrandGrid
+        <ApiBrandGrid
           selectedBrands={data.recentBrands}
           onBrandToggle={
             disabled
@@ -179,7 +179,7 @@ export const StepContent: React.FC<StepContentProps> = ({
 
     case 4:
       return (
-        <BrandGrid
+        <ApiBrandGrid
           selectedBrands={data.selectedBrands}
           onBrandToggle={
             disabled

--- a/src/features/extra-info/components/StepContent.tsx
+++ b/src/features/extra-info/components/StepContent.tsx
@@ -179,16 +179,18 @@ export const StepContent: React.FC<StepContentProps> = ({
 
     case 4:
       return (
-        <ApiBrandGrid
-          selectedBrands={data.selectedBrands}
-          onBrandToggle={
-            disabled
-              ? undefined
-              : brandId => onToggleBrand(brandId, 'selectedBrands')
-          }
-          title="관심있는 브랜드"
-          disabled={disabled}
-        />
+        <div>
+          <ApiBrandGrid
+            selectedBrands={data.selectedBrands}
+            onBrandToggle={
+              disabled
+                ? undefined
+                : brandId => onToggleBrand(brandId, 'selectedBrands')
+            }
+            title="관심있는 브랜드"
+            disabled={disabled}
+          />
+        </div>
       );
 
     default:

--- a/src/features/extra-info/constants/index.ts
+++ b/src/features/extra-info/constants/index.ts
@@ -7,7 +7,7 @@ export const MEMBERSHIP_GRADES: MembershipGrade[] = [
 ];
 
 export const STEP_TITLES = [
-  '이메일 주소를 입력해주세요',
+  '개인 정보를 입력해주세요',
   'LG U+ 멤버십 등급을 선택해주세요',
   '최근 이용한 브랜드를 선택해주세요',
   '관심있는 브랜드를 선택해주세요',

--- a/src/features/extra-info/hooks/useSignupFlow.ts
+++ b/src/features/extra-info/hooks/useSignupFlow.ts
@@ -2,37 +2,38 @@ import { useCallback, useState } from 'react';
 
 import { useSubmitExtraInfo } from '@user/hooks/useUserMutation';
 
-import { EMAIL_REGEX } from '../constants';
+import type { UserGender, UserGrade } from '@/shared/types';
+
 import {
   type CompletedStep,
   type SignupData,
   type StepValidation,
 } from '../types';
 
-const initialData: SignupData = {
-  membershipGrade: '',
-  recentBrands: [],
-  selectedBrands: [],
-  email: '',
-  emailVerified: false,
-};
-
-const stepValidation: StepValidation = {
-  1: data =>
-    data.email !== '' && EMAIL_REGEX.test(data.email) && data.emailVerified,
-  2: data => data.membershipGrade !== '',
-  3: data => data.recentBrands.length > 0,
-  4: data => data.selectedBrands.length > 0,
-};
-
 // 멤버십 등급 매핑 함수
-const mapMembershipGrade = (grade: string): 'GOOD' | 'VIP' | 'VVIP' => {
-  const gradeMap: Record<string, 'GOOD' | 'VIP' | 'VVIP'> = {
+const mapMembershipGrade = (grade: string): UserGrade => {
+  const gradeMap: Record<string, UserGrade> = {
     Excellent: 'GOOD',
     vip: 'VIP',
     vvip: 'VVIP',
   };
   return gradeMap[grade] || 'GOOD';
+};
+
+const initialData: SignupData = {
+  membershipGrade: '',
+  recentBrands: [],
+  selectedBrands: [],
+  age: 0,
+  gender: '',
+  grade: '',
+};
+
+const stepValidation: StepValidation = {
+  1: data => data.age > 0 && data.gender !== '',
+  2: data => data.membershipGrade !== '',
+  3: data => data.recentBrands.length > 0,
+  4: data => data.selectedBrands.length > 0,
 };
 
 export const useSignupFlow = (
@@ -110,8 +111,9 @@ export const useSignupFlow = (
     // 마지막 단계(4단계)에서 API 요청 수행
     if (currentStep === 4) {
       try {
-        // API 요청 데이터 준비
         const apiData = {
+          age: data.age,
+          gender: data.gender as UserGender,
           grade: mapMembershipGrade(data.membershipGrade),
           recentBrands: data.recentBrands,
           interestedBrands: data.selectedBrands,

--- a/src/features/extra-info/types/index.ts
+++ b/src/features/extra-info/types/index.ts
@@ -7,8 +7,9 @@ export interface SignupData {
   membershipGrade: string;
   recentBrands: number[];
   selectedBrands: number[];
-  email: string;
-  emailVerified: boolean;
+  age: number;
+  gender: string;
+  grade: string;
 }
 
 export interface CompletedStep {

--- a/src/features/kakao-map/components/search/MapSearchInput.tsx
+++ b/src/features/kakao-map/components/search/MapSearchInput.tsx
@@ -74,7 +74,7 @@ export const KeywordSearchInput: React.FC<KeywordSearchInputProps> = ({
           className={`
             flex-1 px-2 h-full
             bg-transparent border-none outline-none
-            text-sm font-semibold text-black placeholder-text-teritary
+            text-base md:text-sm font-semibold text-black placeholder-text-teritary
             disabled:cursor-wait disabled:text-gray-400
           `}
           aria-label="장소 검색"
@@ -158,7 +158,7 @@ export const MapSearchInput: React.FC<{
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         className={`
-          w-full h-[44px] px-[25px] text-sm font-semibold text-black placeholder-text-teritary rounded-md pr-10 transition-all duration-200
+          w-full h-[44px] px-[25px] text-base md:text-sm font-semibold text-black placeholder-text-teritary rounded-md pr-10 transition-all duration-200
           ${variant === 'white' ? 'bg-white border border-gray-200 shadow-lg hover:shadow-xl focus:shadow-xl' : 'bg-light-gray shadow-lg hover:shadow-xl focus:shadow-xl'}
         `}
         aria-label="장소 검색"

--- a/src/index.css
+++ b/src/index.css
@@ -521,6 +521,7 @@
     min-height: 100vh;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    touch-action: manipulation;
   }
 
   /* 기본 요소 스타일링 */

--- a/src/pages/user/extra-info/ExtraInfo.tsx
+++ b/src/pages/user/extra-info/ExtraInfo.tsx
@@ -110,9 +110,9 @@ const ImprovedSignupFlow: React.FC = () => {
   const submitError = submitExtraInfo.error;
 
   return (
-    <div>
-      <div className="sticky top-0 z-10 bg-white">
-        <div className="mx-auto px-4 py-2">
+    <div className="relative">
+      <div className="fixed top-0 left-0 w-full z-50 bg-white">
+        <div className="mx-auto px-4 py-6">
           <div className="flex items-center gap-3">
             <div className="flex-1 bg-gray-200 rounded-full h-2">
               <div

--- a/src/pages/user/extra-info/ExtraInfo.tsx
+++ b/src/pages/user/extra-info/ExtraInfo.tsx
@@ -4,10 +4,11 @@ import { CompletedSteps } from '@extra-info/components/CompletedSteps';
 import { CurrentStep } from '@extra-info/components/CurrentStep';
 import { useSignupFlow } from '@extra-info/hooks/useSignupFlow';
 import type { SignupData } from '@extra-info/types';
-import type { UserGrade } from '@user/api/types';
 import { useSubmitExtraInfo } from '@user/hooks/useUserMutation';
 import { LayoutGroup } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+
+import type { UserGender, UserGrade } from '@/shared/types';
 
 // 멤버십 등급 매핑 함수
 const mapMembershipGrade = (grade: string): UserGrade => {
@@ -38,6 +39,8 @@ const ImprovedSignupFlow: React.FC = () => {
 
         // API 요청 데이터 준비
         const apiData = {
+          age: data.age,
+          gender: data.gender as UserGender,
           grade: mapMembershipGrade(data.membershipGrade),
           recentBrands: data.recentBrands,
           interestedBrands: data.selectedBrands,
@@ -191,8 +194,10 @@ const ImprovedSignupFlow: React.FC = () => {
               </p>
             )}
             <hr className="border-gray-600" />
-            <p>Email: {data.email || 'Empty'}</p>
-            <p>Grade: {data.membershipGrade || 'Empty'}</p>
+            <p>Age: {data.age || 'Empty'}</p>
+            <p>Gender: {data.gender || 'Empty'}</p>
+            <p>Membership: {data.membershipGrade || 'Empty'}</p>
+            <p>Mapped Grade: {data.membershipGrade ? mapMembershipGrade(data.membershipGrade) : 'Empty'}</p>
             <p>Recent: {data.recentBrands.length}</p>
             <p>Interest: {data.selectedBrands.length}</p>
           </div>

--- a/src/pages/user/extra-info/ExtraInfo.tsx
+++ b/src/pages/user/extra-info/ExtraInfo.tsx
@@ -112,7 +112,7 @@ const ImprovedSignupFlow: React.FC = () => {
   return (
     <div>
       <div className="sticky top-0 z-10 bg-white">
-        <div className="max-w-md mx-auto px-4 py-2">
+        <div className="mx-auto px-4 py-2">
           <div className="flex items-center gap-3">
             <div className="flex-1 bg-gray-200 rounded-full h-2">
               <div
@@ -130,10 +130,7 @@ const ImprovedSignupFlow: React.FC = () => {
       </div>
 
       {/* 메인 콘텐츠 */}
-      <div
-        className="max-w-md mx-auto bg-white min-h-[calc(100vh-73px)] relative"
-        ref={containerRef}
-      >
+      <div ref={containerRef}>
         <LayoutGroup>
           <CurrentStep
             currentStep={currentStep}

--- a/src/pages/user/extra-info/ExtraInfo.tsx
+++ b/src/pages/user/extra-info/ExtraInfo.tsx
@@ -119,8 +119,8 @@ const ImprovedSignupFlow: React.FC = () => {
   const submitSuccess = submitResult.success === true;
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="sticky top-0 z-30 bg-white">
+    <div>
+      <div className="sticky top-0 z-10 bg-white">
         <div className="max-w-md mx-auto px-4 py-2">
           <div className="flex items-center gap-3">
             <div className="flex-1 bg-gray-200 rounded-full h-2">
@@ -197,7 +197,12 @@ const ImprovedSignupFlow: React.FC = () => {
             <p>Age: {data.age || 'Empty'}</p>
             <p>Gender: {data.gender || 'Empty'}</p>
             <p>Membership: {data.membershipGrade || 'Empty'}</p>
-            <p>Mapped Grade: {data.membershipGrade ? mapMembershipGrade(data.membershipGrade) : 'Empty'}</p>
+            <p>
+              Mapped Grade:{' '}
+              {data.membershipGrade
+                ? mapMembershipGrade(data.membershipGrade)
+                : 'Empty'}
+            </p>
             <p>Recent: {data.recentBrands.length}</p>
             <p>Interest: {data.selectedBrands.length}</p>
           </div>

--- a/src/pages/user/extra-info/ExtraInfo.tsx
+++ b/src/pages/user/extra-info/ExtraInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import { CompletedSteps } from '@extra-info/components/CompletedSteps';
 import { CurrentStep } from '@extra-info/components/CurrentStep';
@@ -96,6 +96,12 @@ const ImprovedSignupFlow: React.FC = () => {
     }
   }, [currentStep, data, handleComplete, originalGoToNextStep]);
 
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [currentStep]);
+
   // 전체 플로우 리셋 함수
   const handleReset = useCallback(() => {
     resetFlow();
@@ -130,7 +136,7 @@ const ImprovedSignupFlow: React.FC = () => {
       </div>
 
       {/* 메인 콘텐츠 */}
-      <div ref={containerRef}>
+      <div ref={containerRef} className="h-[calc(100vh-64px)] overflow-y-auto">
         <LayoutGroup>
           <CurrentStep
             currentStep={currentStep}

--- a/src/pages/user/extra-info/ExtraInfo.tsx
+++ b/src/pages/user/extra-info/ExtraInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 import { CompletedSteps } from '@extra-info/components/CompletedSteps';
 import { CurrentStep } from '@extra-info/components/CurrentStep';
@@ -7,6 +7,7 @@ import type { SignupData } from '@extra-info/types';
 import { useSubmitExtraInfo } from '@user/hooks/useUserMutation';
 import { LayoutGroup } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import type { UserGender, UserGrade } from '@/shared/types';
 
@@ -26,17 +27,11 @@ const ImprovedSignupFlow: React.FC = () => {
 
   // API 상태 관리
   const submitExtraInfo = useSubmitExtraInfo();
-  const [submitResult, setSubmitResult] = useState<{
-    success?: boolean;
-    message?: string;
-  }>({});
 
   // 회원가입 완료 처리 함수
   const handleComplete = useCallback(
     async (data: SignupData) => {
       try {
-        setSubmitResult({}); // 이전 결과 초기화
-
         // API 요청 데이터 준비
         const apiData = {
           age: data.age,
@@ -49,28 +44,28 @@ const ImprovedSignupFlow: React.FC = () => {
         // API 요청 실행
         await submitExtraInfo.mutateAsync(apiData);
 
-        // 성공 처리
-        setSubmitResult({
-          success: true,
-          message: '회원가입이 성공적으로 완료되었습니다!',
+        // 성공 처리 - 토스트 알림
+        toast.success('🎉 회원가입이 완료되었습니다!', {
+          description: '환영합니다! 홈페이지로 이동합니다.',
+          duration: 2000,
         });
 
-        // 성공 후 잠시 대기한 다음 홈으로 이동
+        // 성공 후 홈으로 리다이렉트
         setTimeout(() => {
           navigate('/', { replace: true });
-        }, 2000);
+        }, 1500);
       } catch (error) {
         console.error('회원가입 실패:', error);
 
-        // 에러 메시지 설정
+        // 에러 처리 - 토스트 알림
         const errorMessage =
           error instanceof Error
             ? error.message
             : '회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.';
 
-        setSubmitResult({
-          success: false,
-          message: errorMessage,
+        toast.error('회원가입 실패', {
+          description: errorMessage,
+          duration: 4000,
         });
       }
     },
@@ -104,7 +99,6 @@ const ImprovedSignupFlow: React.FC = () => {
   // 전체 플로우 리셋 함수
   const handleReset = useCallback(() => {
     resetFlow();
-    setSubmitResult({});
     submitExtraInfo.reset(); // mutation 상태도 리셋
   }, [resetFlow, submitExtraInfo]);
 
@@ -113,10 +107,7 @@ const ImprovedSignupFlow: React.FC = () => {
 
   // 제출 상태들
   const isSubmitting = submitExtraInfo.isPending;
-  const submitError =
-    submitExtraInfo.error ||
-    (submitResult.success === false ? new Error(submitResult.message) : null);
-  const submitSuccess = submitResult.success === true;
+  const submitError = submitExtraInfo.error;
 
   return (
     <div>
@@ -155,59 +146,11 @@ const ImprovedSignupFlow: React.FC = () => {
             onPrev={goToPrevStep}
             isSubmitting={isSubmitting}
             submitError={submitError}
-            submitSuccess={submitSuccess}
           />
 
           <CompletedSteps completedSteps={completedSteps} />
         </LayoutGroup>
       </div>
-
-      {/* 성공 시 자동 이동 알림 */}
-      {submitSuccess && (
-        <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-40">
-          <div className="bg-green-600 text-white px-6 py-3 rounded-lg shadow-lg flex items-center gap-2">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fillRule="evenodd"
-                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                clipRule="evenodd"
-              />
-            </svg>
-            <span className="text-sm font-medium">
-              잠시 후 홈페이지로 이동합니다
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* 개발 환경 디버그 정보 */}
-      {process.env.NODE_ENV === 'development' && (
-        <div className="fixed bottom-4 right-4 bg-black bg-opacity-80 text-white p-3 rounded-lg text-xs font-mono max-w-xs">
-          <div className="space-y-1">
-            <p>Step: {currentStep}/4</p>
-            <p>Valid: {currentStepValid ? '✓' : '✗'}</p>
-            <p>Submitting: {isSubmitting ? '✓' : '✗'}</p>
-            <p>Success: {submitSuccess ? '✓' : '✗'}</p>
-            {submitError && (
-              <p className="text-red-300 text-wrap">
-                Error: {submitError.message}
-              </p>
-            )}
-            <hr className="border-gray-600" />
-            <p>Age: {data.age || 'Empty'}</p>
-            <p>Gender: {data.gender || 'Empty'}</p>
-            <p>Membership: {data.membershipGrade || 'Empty'}</p>
-            <p>
-              Mapped Grade:{' '}
-              {data.membershipGrade
-                ? mapMembershipGrade(data.membershipGrade)
-                : 'Empty'}
-            </p>
-            <p>Recent: {data.recentBrands.length}</p>
-            <p>Interest: {data.selectedBrands.length}</p>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -33,6 +33,7 @@ const Layout = () => {
     pathname === PATH.ADMIN;
 
   const isMap = pathname === '/' || pathname.startsWith(PATH.MAP);
+  const isOnboarding = pathname === PATH.EXTRA_INFO;
 
   return (
     <div
@@ -41,7 +42,7 @@ const Layout = () => {
       style={isMap ? { minWidth: 0 } : undefined}
     >
       <BaseLayout isMap={isMap}>
-        <SidebarSheet />
+        {!isOnboarding && <SidebarSheet />}
         <Outlet />
         {showBottomNav && <BottomNavigation />}
       </BaseLayout>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -75,11 +75,7 @@ export const AppRoutes = () => {
           />
           <Route
             path={PATH.EXTRA_INFO}
-            element={
-              <UserRoute>
-                <ExtraInfo />
-              </UserRoute>
-            }
+            element={<ExtraInfo />}
           />
           <Route path={PATH.MAP} element={<MapPage />} />
           <Route path="/map/:uuid" element={<MapPage />} />

--- a/src/shared/components/bottom_sheet/BaseBottomSheet.tsx
+++ b/src/shared/components/bottom_sheet/BaseBottomSheet.tsx
@@ -66,13 +66,14 @@ export const BaseBottomSheet: React.FC<BaseBottomSheetProps> = ({
           <div
             role="button"
             tabIndex={0}
-            className="absolute inset-0 bg-black/40 backdrop-blur-sm z-40"
+            className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[9998]"
+            style={{ backdropFilter: 'blur(4px)' }}
             onClick={closeOnBackdrop ? onClose : undefined}
             onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onClose?.()}
           />
 
           <motion.div
-            className={`absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-sm z-50 flex flex-col border border-light-gray ${getHeightClass()} ${className}`}
+            className={`fixed bottom-0 left-0 right-0 lg:left-[calc((100vw-500px)/2)] lg:right-auto lg:w-[500px] xl:left-[calc((100vw-600px)/2)] xl:w-[600px] 2xl:left-[calc((100vw-700px)/2)] 2xl:w-[700px] bg-white rounded-t-2xl shadow-sm z-[9999] flex flex-col border border-light-gray ${getHeightClass()} ${className}`}
             initial={{ y: '100%' }}
             animate={{ y: 0 }}
             exit={{ y: '100%' }}

--- a/src/shared/components/brand_grid/ApiBrandGrid.tsx
+++ b/src/shared/components/brand_grid/ApiBrandGrid.tsx
@@ -55,7 +55,7 @@ export const ApiBrandGrid: React.FC<BrandGridProps> = ({
     );
   }
 
-  const brands = apiResponse?.data.map(convertApiBrandToBrand) || [];
+  const brands = apiResponse?.data?.map(convertApiBrandToBrand) || [];
 
   return (
     <div className="space-y-6">

--- a/src/shared/components/brand_grid/ApiBrandGrid.tsx
+++ b/src/shared/components/brand_grid/ApiBrandGrid.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { BrandLogo } from '@/shared/components';
+import { getInterestBrands } from '@/shared/components/brand_grid/api/brandApi';
+import {
+  type BrandGridProps,
+  convertApiBrandToBrand,
+} from '@/shared/components/brand_grid/brand.type';
+
+export const ApiBrandGrid: React.FC<BrandGridProps> = ({
+  selectedBrands,
+  onBrandToggle,
+  title,
+  disabled = false,
+}) => {
+  const {
+    data: apiResponse,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['interest-brands'],
+    queryFn: getInterestBrands,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <p className="text-sm text-gray-600 mb-4">{title}</p>
+          <div className="grid grid-cols-3 gap-6 justify-items-center">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div key={index} className="flex flex-col items-center space-y-2">
+                <div className="w-16 h-16 rounded-full bg-gray-200 animate-pulse" />
+                <div className="w-12 h-3 bg-gray-200 rounded animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <p className="text-sm text-gray-600 mb-4">{title}</p>
+          <div className="text-center text-red-500">
+            브랜드 정보를 불러오는데 실패했습니다.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const brands = apiResponse?.data.map(convertApiBrandToBrand) || [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-sm text-gray-600 mb-4">{title}</p>
+        <div className="grid grid-cols-3 gap-6 justify-items-center">
+          {brands.map((brand, index) => {
+            const isSelected = selectedBrands.includes(brand.id);
+
+            return (
+              <BrandLogo
+                key={brand.id}
+                brand={brand}
+                isSelected={isSelected}
+                onClick={
+                  onBrandToggle ? () => onBrandToggle(brand.id) : undefined
+                }
+                delay={index * 0.1}
+                disabled={disabled}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/shared/components/brand_grid/ApiBrandGrid.tsx
+++ b/src/shared/components/brand_grid/ApiBrandGrid.tsx
@@ -55,7 +55,7 @@ export const ApiBrandGrid: React.FC<BrandGridProps> = ({
     );
   }
 
-  const brands = apiResponse?.data?.map(convertApiBrandToBrand) || [];
+  const brands = apiResponse?.map(convertApiBrandToBrand) || [];
 
   return (
     <div className="space-y-6">

--- a/src/shared/components/brand_grid/api/brandApi.ts
+++ b/src/shared/components/brand_grid/api/brandApi.ts
@@ -1,8 +1,20 @@
 import { client } from '@/shared/client';
+import type { ApiResponse } from '@/shared/client/client.type';
 
-import { type ApiBrandResponse } from '../brand.type';
+import { BRAND_ENDPOINTS } from './endpoints';
+import type { ApiBrandResponse } from './types';
 
+/**
+ * 관심 브랜드 목록 조회 API
+ */
 export const getInterestBrands = async (): Promise<ApiBrandResponse> => {
-  const response = await client.get<ApiBrandResponse>('/brand-list/interest');
-  return response.data;
+  const res = await client.get<ApiResponse<ApiBrandResponse>>(
+    BRAND_ENDPOINTS.BRAND
+  );
+
+  if (!res.data.data) {
+    throw new Error('Invalid API response: missing data');
+  }
+
+  return res.data.data;
 };

--- a/src/shared/components/brand_grid/api/brandApi.ts
+++ b/src/shared/components/brand_grid/api/brandApi.ts
@@ -2,15 +2,13 @@ import { client } from '@/shared/client';
 import type { ApiResponse } from '@/shared/client/client.type';
 
 import { BRAND_ENDPOINTS } from './endpoints';
-import type { ApiBrandResponse } from './types';
+import type { ApiBrand } from './types';
 
 /**
  * 관심 브랜드 목록 조회 API
  */
-export const getInterestBrands = async (): Promise<ApiBrandResponse> => {
-  const res = await client.get<ApiResponse<ApiBrandResponse>>(
-    BRAND_ENDPOINTS.BRAND
-  );
+export const getInterestBrands = async (): Promise<ApiBrand[]> => {
+  const res = await client.get<ApiResponse<ApiBrand[]>>(BRAND_ENDPOINTS.BRAND);
 
   if (!res.data.data) {
     throw new Error('Invalid API response: missing data');

--- a/src/shared/components/brand_grid/api/brandApi.ts
+++ b/src/shared/components/brand_grid/api/brandApi.ts
@@ -1,0 +1,8 @@
+import { client } from '@/shared/client';
+
+import { type ApiBrandResponse } from '../brand.type';
+
+export const getInterestBrands = async (): Promise<ApiBrandResponse> => {
+  const response = await client.get<ApiBrandResponse>('/brand-list/interest');
+  return response.data;
+};

--- a/src/shared/components/brand_grid/api/endpoints.ts
+++ b/src/shared/components/brand_grid/api/endpoints.ts
@@ -1,0 +1,3 @@
+export const BRAND_ENDPOINTS = {
+  BRAND: '/brand-list/interest',
+};

--- a/src/shared/components/brand_grid/api/index.ts
+++ b/src/shared/components/brand_grid/api/index.ts
@@ -1,3 +1,3 @@
 export { getInterestBrands } from './brandApi';
 export { BRAND_ENDPOINTS } from './endpoints';
-export type { ApiBrand, ApiBrandResponse } from './types';
+export type { ApiBrand } from './types';

--- a/src/shared/components/brand_grid/api/index.ts
+++ b/src/shared/components/brand_grid/api/index.ts
@@ -1,0 +1,3 @@
+export { getInterestBrands } from './brandApi';
+export { BRAND_ENDPOINTS } from './endpoints';
+export type { ApiBrand, ApiBrandResponse } from './types';

--- a/src/shared/components/brand_grid/api/types.ts
+++ b/src/shared/components/brand_grid/api/types.ts
@@ -1,0 +1,12 @@
+import type { ApiResponse } from '@/shared/client/client.type';
+
+/**
+ * API 브랜드 정보 타입
+ */
+export interface ApiBrand {
+  brandId: number;
+  brandName: string;
+  logoImage: string;
+}
+
+export type ApiBrandResponse = ApiResponse<ApiBrand[]>;

--- a/src/shared/components/brand_grid/api/types.ts
+++ b/src/shared/components/brand_grid/api/types.ts
@@ -1,5 +1,3 @@
-import type { ApiResponse } from '@/shared/client/client.type';
-
 /**
  * API 브랜드 정보 타입
  */
@@ -8,5 +6,3 @@ export interface ApiBrand {
   brandName: string;
   logoImage: string;
 }
-
-export type ApiBrandResponse = ApiResponse<ApiBrand[]>;

--- a/src/shared/components/brand_grid/brand.type.ts
+++ b/src/shared/components/brand_grid/brand.type.ts
@@ -9,6 +9,18 @@ export interface Brand {
   imagePath: string;
 }
 
+export interface ApiBrand {
+  brandId: number;
+  brandName: string;
+  logoImage: string;
+}
+
+export interface ApiBrandResponse {
+  statusCode: number;
+  message: string;
+  data: ApiBrand[];
+}
+
 export interface BrandGridProps {
   selectedBrands: number[];
   onBrandToggle?: (brandId: number) => void;
@@ -23,3 +35,15 @@ export interface BrandLogoProps {
   delay?: number;
   disabled?: boolean;
 }
+
+// API 브랜드를 기존 Brand 타입으로 변환하는 함수
+export const convertApiBrandToBrand = (apiBrand: ApiBrand): Brand => ({
+  id: apiBrand.brandId,
+  name: apiBrand.brandName,
+  color: '#3182CE', // 기본 색상
+  bgColor: 'bg-blue-500',
+  textColor: 'text-white',
+  imagePath: apiBrand.logoImage,
+  logo: apiBrand.logoImage,
+  logoAlt: apiBrand.brandName,
+});

--- a/src/shared/components/brand_grid/brand.type.ts
+++ b/src/shared/components/brand_grid/brand.type.ts
@@ -1,3 +1,5 @@
+import type { ApiBrand } from './api/types';
+
 export interface Brand {
   id: number;
   name: string;
@@ -7,18 +9,6 @@ export interface Brand {
   logo?: string;
   logoAlt?: string;
   imagePath: string;
-}
-
-export interface ApiBrand {
-  brandId: number;
-  brandName: string;
-  logoImage: string;
-}
-
-export interface ApiBrandResponse {
-  statusCode: number;
-  message: string;
-  data: ApiBrand[];
 }
 
 export interface BrandGridProps {
@@ -36,7 +26,9 @@ export interface BrandLogoProps {
   disabled?: boolean;
 }
 
-// API 브랜드를 기존 Brand 타입으로 변환하는 함수
+/**
+ * API 브랜드를 기존 Brand 타입으로 변환하는 함수
+ */
 export const convertApiBrandToBrand = (apiBrand: ApiBrand): Brand => ({
   id: apiBrand.brandId,
   name: apiBrand.brandName,

--- a/src/shared/components/brand_grid/index.tsx
+++ b/src/shared/components/brand_grid/index.tsx
@@ -1,8 +1,16 @@
 export { BrandGrid } from './BrandGrid';
+export { ApiBrandGrid } from './ApiBrandGrid';
 export { BrandLogo } from './BrandLogo';
 
-export type { Brand, BrandGridProps, BrandLogoProps } from './brand.type';
+export type {
+  Brand,
+  BrandGridProps,
+  BrandLogoProps,
+  ApiBrand,
+  ApiBrandResponse,
+} from './brand.type';
 
 export { BRANDS } from './constants';
+export { getInterestBrands } from './api/brandApi';
 
 export { BrandGrid as default } from './BrandGrid';

--- a/src/shared/components/brand_grid/index.tsx
+++ b/src/shared/components/brand_grid/index.tsx
@@ -8,6 +8,6 @@ export { BRANDS } from './constants';
 
 // API exports
 export { getInterestBrands, BRAND_ENDPOINTS } from './api';
-export type { ApiBrand, ApiBrandResponse } from './api';
+export type { ApiBrand } from './api';
 
 export { BrandGrid as default } from './BrandGrid';

--- a/src/shared/components/brand_grid/index.tsx
+++ b/src/shared/components/brand_grid/index.tsx
@@ -2,15 +2,12 @@ export { BrandGrid } from './BrandGrid';
 export { ApiBrandGrid } from './ApiBrandGrid';
 export { BrandLogo } from './BrandLogo';
 
-export type {
-  Brand,
-  BrandGridProps,
-  BrandLogoProps,
-  ApiBrand,
-  ApiBrandResponse,
-} from './brand.type';
+export type { Brand, BrandGridProps, BrandLogoProps } from './brand.type';
 
 export { BRANDS } from './constants';
-export { getInterestBrands } from './api/brandApi';
+
+// API exports
+export { getInterestBrands, BRAND_ENDPOINTS } from './api';
+export type { ApiBrand, ApiBrandResponse } from './api';
 
 export { BrandGrid as default } from './BrandGrid';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -7,8 +7,8 @@ export { DragBottomSheet } from './bottom_sheet/DragBottomSheet';
 export { NavigationBottomSheet } from './bottom_sheet/NavigationBottomSheet';
 export { SelectionBottomSheet } from './bottom_sheet/SelectionBottomSheet';
 
+export { ApiBrandGrid } from './brand_grid/ApiBrandGrid';
 export { BrandGrid } from './brand_grid/BrandGrid';
-
 export { BrandLogo } from './brand_grid/BrandLogo';
 
 export { ButtonBase } from './buttons/ButtonBase';

--- a/src/shared/components/search_input/SearchInputVariants.ts
+++ b/src/shared/components/search_input/SearchInputVariants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const SearchInputVariants = cva(
-  'w-full h-[44px] px-[25px] text-sm font-semibold text-black placeholder-text-teritary rounded-md pr-10 transition-all duration-200',
+  'w-full h-[44px] px-[25px] text-base md:text-sm font-semibold text-black placeholder-text-teritary rounded-md pr-10 transition-all duration-200',
   {
     variants: {
       variant: {

--- a/src/shared/components/shadcn/ui/input-otp.tsx
+++ b/src/shared/components/shadcn/ui/input-otp.tsx
@@ -41,7 +41,7 @@ const InputOTPSlot = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        'relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+        'relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-base md:text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
         isActive && 'z-10 ring-2 ring-ring ring-offset-background',
         className
       )}

--- a/src/shared/components/shadcn/ui/select.tsx
+++ b/src/shared/components/shadcn/ui/select.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className
     )}
     {...props}

--- a/src/shared/msw/handlers/brand.ts
+++ b/src/shared/msw/handlers/brand.ts
@@ -1,7 +1,9 @@
 import { HttpResponse, http } from 'msw';
 
+import { BRAND_ENDPOINTS } from '@/shared/components/brand_grid/api/endpoints';
+
 export const brandHandlers = [
-  http.get('/brand-list/interest', () => {
+  http.get(BRAND_ENDPOINTS.BRAND, () => {
     return HttpResponse.json({
       statusCode: 0,
       message: '정상 처리 되었습니다.',

--- a/src/shared/msw/handlers/brand.ts
+++ b/src/shared/msw/handlers/brand.ts
@@ -1,50 +1,49 @@
-import { HttpResponse, http } from 'msw';
+import { http } from 'msw';
 
 import { BRAND_ENDPOINTS } from '@/shared/components/brand_grid/api/endpoints';
+import { createResponse } from '@/shared/utils/createResponse';
 
 export const brandHandlers = [
   http.get(BRAND_ENDPOINTS.BRAND, () => {
-    return HttpResponse.json({
-      statusCode: 0,
-      message: '정상 처리 되었습니다.',
-      data: [
-        {
-          brandId: 39,
-          brandName: '롯데백화점몰',
-          logoImage:
-            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%85%E1%85%A9%E1%86%BA%E1%84%83%E1%85%A6%E1%84%87%E1%85%A2%E1%86%A8%E1%84%92%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%B7%E1%84%86%E1%85%A9%E1%86%AF.png',
-        },
-        {
-          brandId: 15,
-          brandName: '코엑스아쿠아리움',
-          logoImage:
-            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%8F%E1%85%A9%E1%84%8B%E1%85%A6%E1%86%A8%E1%84%89%E1%85%B3%E1%84%8B%E1%85%A1%E1%84%8F%E1%85%AE%E1%84%8B%E1%85%A1%E1%84%85%E1%85%B5%E1%84%8B%E1%85%AE%E1%86%B7.png',
-        },
-        {
-          brandId: 35,
-          brandName: 'LG생활건강샵 U+패밀리샵',
-          logoImage:
-            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/LG%E1%84%89%E1%85%A2%E1%86%BC%E1%84%92%E1%85%AA%E1%86%AF%E1%84%80%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A1%E1%86%BC%E1%84%89%E1%85%A3%E1%86%B8%20U%2B%E1%84%91%E1%85%A2%E1%86%BC%E1%84%85%E1%85%B5%E1%84%89%E1%85%A3%E1%86%B8.jpg',
-        },
-        {
-          brandId: 10,
-          brandName: '롯데월드 아이스링크',
-          logoImage:
-            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%85%E1%85%A9%E1%86%BA%E1%84%83%E1%85%A6%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3%20%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%85%E1%85%B5%E1%86%BC%E1%84%8F%E1%85%B3.png',
-        },
-        {
-          brandId: 25,
-          brandName: 'CGV',
-          logoImage:
-            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/CGV.png',
-        },
-        {
-          brandId: 30,
-          brandName: '베스킨라빈스',
-          logoImage:
-            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%87%E1%85%A6%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%86%AB%E1%84%85%E1%85%A1%E1%84%87%E1%85%B3%E1%86%AB%E1%84%89%E1%85%B3.png',
-        },
-      ],
-    });
+    const mockBrands = [
+      {
+        brandId: 39,
+        brandName: '롯데백화점몰',
+        logoImage:
+          'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%85%E1%85%A9%E1%86%BA%E1%84%83%E1%85%A6%E1%84%87%E1%85%A2%E1%86%A8%E1%84%92%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%B7%E1%84%86%E1%85%A9%E1%86%AF.png',
+      },
+      {
+        brandId: 15,
+        brandName: '코엑스아쿠아리움',
+        logoImage:
+          'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%8F%E1%85%A9%E1%84%8B%E1%85%A6%E1%86%A8%E1%84%89%E1%85%B3%E1%84%8B%E1%85%A1%E1%84%8F%E1%85%AE%E1%84%8B%E1%85%A1%E1%84%85%E1%85%B5%E1%84%8B%E1%85%AE%E1%86%B7.png',
+      },
+      {
+        brandId: 35,
+        brandName: 'LG생활건강샵 U+패밀리샵',
+        logoImage:
+          'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/LG%E1%84%89%E1%85%A2%E1%86%BC%E1%84%92%E1%85%AA%E1%86%AF%E1%84%80%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A1%E1%86%BC%E1%84%89%E1%85%A3%E1%86%B8%20U%2B%E1%84%91%E1%85%A2%E1%86%BC%E1%84%85%E1%85%B5%E1%84%89%E1%85%A3%E1%86%B8.jpg',
+      },
+      {
+        brandId: 10,
+        brandName: '롯데월드 아이스링크',
+        logoImage:
+          'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%85%E1%85%A9%E1%86%BA%E1%84%83%E1%85%A6%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3%20%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%85%E1%85%B5%E1%86%BC%E1%84%8F%E1%85%B3.png',
+      },
+      {
+        brandId: 25,
+        brandName: 'CGV',
+        logoImage:
+          'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/CGV.png',
+      },
+      {
+        brandId: 30,
+        brandName: '베스킨라빈스',
+        logoImage:
+          'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%87%E1%85%A6%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%86%AB%E1%84%85%E1%85%A1%E1%84%87%E1%85%B3%E1%86%AB%E1%84%89%E1%85%B3.png',
+      },
+    ];
+
+    return createResponse(mockBrands, '관심 브랜드 목록 조회 성공');
   }),
 ];

--- a/src/shared/msw/handlers/brand.ts
+++ b/src/shared/msw/handlers/brand.ts
@@ -1,0 +1,48 @@
+import { HttpResponse, http } from 'msw';
+
+export const brandHandlers = [
+  http.get('/brand-list/interest', () => {
+    return HttpResponse.json({
+      statusCode: 0,
+      message: '정상 처리 되었습니다.',
+      data: [
+        {
+          brandId: 39,
+          brandName: '롯데백화점몰',
+          logoImage:
+            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%85%E1%85%A9%E1%86%BA%E1%84%83%E1%85%A6%E1%84%87%E1%85%A2%E1%86%A8%E1%84%92%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%B7%E1%84%86%E1%85%A9%E1%86%AF.png',
+        },
+        {
+          brandId: 15,
+          brandName: '코엑스아쿠아리움',
+          logoImage:
+            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%8F%E1%85%A9%E1%84%8B%E1%85%A6%E1%86%A8%E1%84%89%E1%85%B3%E1%84%8B%E1%85%A1%E1%84%8F%E1%85%AE%E1%84%8B%E1%85%A1%E1%84%85%E1%85%B5%E1%84%8B%E1%85%AE%E1%86%B7.png',
+        },
+        {
+          brandId: 35,
+          brandName: 'LG생활건강샵 U+패밀리샵',
+          logoImage:
+            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/LG%E1%84%89%E1%85%A2%E1%86%BC%E1%84%92%E1%85%AA%E1%86%AF%E1%84%80%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A1%E1%86%BC%E1%84%89%E1%85%A3%E1%86%B8%20U%2B%E1%84%91%E1%85%A2%E1%86%BC%E1%84%85%E1%85%B5%E1%84%89%E1%85%A3%E1%86%B8.jpg',
+        },
+        {
+          brandId: 10,
+          brandName: '롯데월드 아이스링크',
+          logoImage:
+            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%85%E1%85%A9%E1%86%BA%E1%84%83%E1%85%A6%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3%20%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%85%E1%85%B5%E1%86%BC%E1%84%8F%E1%85%B3.png',
+        },
+        {
+          brandId: 25,
+          brandName: 'CGV',
+          logoImage:
+            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/CGV.png',
+        },
+        {
+          brandId: 30,
+          brandName: '베스킨라빈스',
+          logoImage:
+            'https://uhyu-bucket.s3.ap-northeast-2.amazonaws.com/logo/%E1%84%87%E1%85%A6%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%86%AB%E1%84%85%E1%85%A1%E1%84%87%E1%85%B3%E1%86%AB%E1%84%89%E1%85%B3.png',
+        },
+      ],
+    });
+  }),
+];

--- a/src/shared/msw/handlers/index.ts
+++ b/src/shared/msw/handlers/index.ts
@@ -1,6 +1,7 @@
 import { adminHandlers } from './admin';
 import { barcodeHandlers } from './barcode';
 import { benefitHandlers } from './benefit';
+import { brandHandlers } from './brand';
 import { homeHandlers } from './home';
 import { mapHandlers } from './map';
 import { mymapHandlers } from './mymap';
@@ -13,6 +14,7 @@ export const handlers = [
   ...mapHandlers,
   ...homeHandlers,
   ...benefitHandlers,
+  ...brandHandlers,
   ...mypageHandlers,
   ...adminHandlers,
   ...mymapHandlers,

--- a/src/shared/msw/handlers/user.ts
+++ b/src/shared/msw/handlers/user.ts
@@ -4,7 +4,7 @@ import { createErrorResponse } from '@/shared/utils/createErrorResponse';
 import { createResponse } from '@/shared/utils/createResponse';
 
 export const userHandlers = [
-  http.post('/users/check-email', async ({ request }) => {
+  http.post('/user/check-email', async ({ request }) => {
     const body = (await request.json()) as { email: string };
     const email = body.email;
 
@@ -27,7 +27,7 @@ export const userHandlers = [
     );
   }),
 
-  http.post('/users/extra-info', async ({ request }) => {
+  http.post('/user/extra-info', async ({ request }) => {
     try {
       const body = (await request.json()) as {
         age?: number;

--- a/src/shared/msw/handlers/user.ts
+++ b/src/shared/msw/handlers/user.ts
@@ -30,20 +30,67 @@ export const userHandlers = [
   http.post('/users/extra-info', async ({ request }) => {
     try {
       const body = (await request.json()) as {
-        grade?: string;
-        recentBrands?: string[];
-        interestedBrands?: string[];
+        age?: number;
+        gender?: 'MALE' | 'FEMALE' | 'OTHER';
+        grade?: 'GOOD' | 'VIP' | 'VVIP';
+        recentBrands?: number[];
+        interestedBrands?: number[];
       };
 
-      // 에러 시나리오: 필수 필드 누락
-      if (!body.grade || !body.recentBrands || !body.interestedBrands) {
-        return createErrorResponse('필수 입력 항목이 누락되었습니다', 400);
+      console.log('🔄 MSW: 온보딩 추가정보 요청 받음:', body);
+
+      // 에러 시나리오: 필수 필드 누락 검증
+      const missingFields = [];
+      if (!body.age || body.age <= 0) missingFields.push('age');
+      if (!body.gender) missingFields.push('gender');
+      if (!body.grade) missingFields.push('grade');
+      if (!body.recentBrands || body.recentBrands.length === 0) missingFields.push('recentBrands');
+      if (!body.interestedBrands || body.interestedBrands.length === 0) missingFields.push('interestedBrands');
+
+      if (missingFields.length > 0) {
+        return createErrorResponse(
+          `필수 입력 항목이 누락되었습니다: ${missingFields.join(', ')}`,
+          400
+        );
       }
 
-      // 유효성 검사 등 필요시 추가
-      return createResponse('SUCCESS', '회원가입 추가정보 입력 성공', 0);
+      // 유효성 검사: 나이 범위
+      if (body.age! < 10 || body.age! > 100) {
+        return createErrorResponse('나이는 10세 이상 100세 이하여야 합니다', 400);
+      }
+
+      // 유효성 검사: 성별 값
+      if (!['MALE', 'FEMALE', 'OTHER'].includes(body.gender!)) {
+        return createErrorResponse('올바른 성별 값이 아닙니다', 400);
+      }
+
+      // 유효성 검사: 등급 값
+      if (!['GOOD', 'VIP', 'VVIP'].includes(body.grade!)) {
+        return createErrorResponse('올바른 등급 값이 아닙니다', 400);
+      }
+
+      // 유효성 검사: 브랜드 ID 배열
+      if (!Array.isArray(body.recentBrands) || !Array.isArray(body.interestedBrands)) {
+        return createErrorResponse('브랜드 정보는 배열 형태여야 합니다', 400);
+      }
+
+      // 성공 응답
+      console.log('✅ MSW: 온보딩 추가정보 저장 성공');
+      return createResponse(
+        {
+          userId: 1, // MSW에서는 인증된 사용자 ID로 고정
+          age: body.age,
+          gender: body.gender,
+          grade: body.grade,
+          recentBrandsCount: body.recentBrands.length,
+          interestedBrandsCount: body.interestedBrands.length,
+          registeredAt: new Date().toISOString(),
+        },
+        '회원가입 추가정보가 성공적으로 저장되었습니다',
+        200
+      );
     } catch (error) {
-      console.error('Extra info submission error:', error);
+      console.error('❌ MSW: Extra info submission error:', error);
       return createErrorResponse('서버 내부 오류가 발생했습니다', 500);
     }
   }),

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -15,7 +15,7 @@
 // 기본 사용자 타입들
 export type UserRole = 'USER' | 'ADMIN';
 export type UserGrade = 'GOOD' | 'VIP' | 'VVIP';
-export type UserGender = 'MALE' | 'FEMALE';
+export type UserGender = 'MALE' | 'FEMALE' | 'OTHER';
 
 // 마커 관련 타입
 export interface Marker {
@@ -69,6 +69,8 @@ export interface UpdateUserRequest {
 
 // 사용자 추가 정보 요청
 export interface UserExtraInfoRequest {
+  age: number;
+  gender: UserGender;
   grade: UserGrade;
   recentBrands: number[];
   interestedBrands: number[];


### PR DESCRIPTION
<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

1. 온보딩 브랜드 선택 API 도입 (ApiBrandGrid 컴포넌트 구현)
2. 온보딩 페이지 레이아웃 개선 및 일관성 보장 ( 바텀 네비게이션, 사이드 시트 제거 )
3. 스크롤 및 인터렉션 최적화
4. 변경된 명세 ( 나이, 성별 추가 이메일 (제거) )
5. 바텀 시트 로직 개선 및 최적화


# 현재 UI 캡처

|온보딩 테스트|
|:--:|:--:|:--:|
|![화면 기록 2025-08-01 13 32 51](https://github.com/user-attachments/assets/7f25c537-755d-4e92-84ef-5a6a6a00f894)|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
