### PR TITLE
[FEAT][UHYU-334] 즐겨찾기 조회 MSW 및 즐겨찾기 토글 버튼 추가

### DIFF
--- a/src/features/kakao-map/api/endpoints.ts
+++ b/src/features/kakao-map/api/endpoints.ts
@@ -2,7 +2,7 @@ const MAP = '/map';
 
 export const MAP_ENDPOINTS = {
   /** 주변 매장 목록 조회 */
-  GET_NEARBY_STORES: `${MAP}/stores'`,
+  GET_NEARBY_STORES: `${MAP}/stores`,
   /** 매장 상세 정보 조회 */
   GET_STORE_DETAIL: `${MAP}/detail/stores`,
   /** 매장 즐겨찾기 토글 */

--- a/src/features/kakao-map/api/endpoints.ts
+++ b/src/features/kakao-map/api/endpoints.ts
@@ -1,12 +1,16 @@
+const MAP = '/map';
+
 export const MAP_ENDPOINTS = {
   /** 주변 매장 목록 조회 */
-  GET_NEARBY_STORES: '/map/stores',
+  GET_NEARBY_STORES: `${MAP}/stores'`,
   /** 매장 상세 정보 조회 */
-  GET_STORE_DETAIL: '/map/detail/stores',
+  GET_STORE_DETAIL: `${MAP}/detail/stores`,
   /** 매장 즐겨찾기 토글 */
-  TOGGLE_FAVORITE: '/map',
+  TOGGLE_FAVORITE: MAP,
   /** 카테고리별 브랜드 조회 */
   GET_CATEGORY_BRANDS: '/category',
+  /** 즐겨찾기 조회 */
+  GET_BOOKMARK: `${MAP}/stores/bookmark`,
 } as const;
 
 export type MapEndpoint = (typeof MAP_ENDPOINTS)[keyof typeof MAP_ENDPOINTS];

--- a/src/features/kakao-map/api/mapApi.ts
+++ b/src/features/kakao-map/api/mapApi.ts
@@ -70,19 +70,17 @@ export const mapApi = {
     const response = await client.get<CategoryBrandsResponse>(url);
     return response.data;
   },
-};
 
-/**
- * 즐겨찾기 조회
- * GET map/stores/bookmark
- * @returns
- */
-export const getBookmark = async (): Promise<StoreSummary[]> => {
-  const res = await client.get<ApiResponse<StoreSummary[]>>(
-    MAP_ENDPOINTS.GET_BOOKMARK
-  );
-
-  return res.data.data ?? [];
+    /**
+   * 즐겨찾기 조회
+   * GET map/stores/bookmark
+   */
+  getBookmark: async (): Promise<StoreSummary[]> => {
+    const res = await client.get<ApiResponse<StoreSummary[]>>(
+      MAP_ENDPOINTS.GET_BOOKMARK
+    );
+    return res.data.data ?? [];
+  },
 };
 
 // 타입 가드 함수들 (런타임 안전성을 위한 추가 보안)

--- a/src/features/kakao-map/api/mapApi.ts
+++ b/src/features/kakao-map/api/mapApi.ts
@@ -1,4 +1,5 @@
 import { client } from '@/shared/client';
+import type { ApiResponse } from '@/shared/client/client.type';
 
 import { MAP_ENDPOINTS } from './endpoints';
 import type {
@@ -8,6 +9,7 @@ import type {
   GetStoreDetailParams,
   StoreDetailResponse,
   StoreListResponse,
+  StoreSummary,
   ToggleFavoriteParams,
   ToggleFavoriteResponseType,
 } from './types';
@@ -68,6 +70,19 @@ export const mapApi = {
     const response = await client.get<CategoryBrandsResponse>(url);
     return response.data;
   },
+};
+
+/**
+ * 즐겨찾기 조회
+ * GET map/stores/bookmark
+ * @returns
+ */
+export const getBookmark = async (): Promise<StoreSummary[]> => {
+  const res = await client.get<ApiResponse<StoreSummary[]>>(
+    MAP_ENDPOINTS.GET_BOOKMARK
+  );
+
+  return res.data.data ?? [];
 };
 
 // 타입 가드 함수들 (런타임 안전성을 위한 추가 보안)

--- a/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
+++ b/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
@@ -33,7 +33,7 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
         aria-label="즐겨찾기 필터"
       >
         {isActive ? (
-          <MdStar className="w-6 h-6 text-yellow" />
+          <MdStar className="w-6 h-6 text-primary" />
         ) : (
           <MdStar className="w-6 h-6 text-gray" />
         )}

--- a/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
+++ b/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
@@ -4,7 +4,8 @@ import { MdStar } from 'react-icons/md';
 
 interface BookmarkButtonProps {
   isActive: boolean;
-  onClick: () => void;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  disabled?: boolean;
   className?: string;
 }
 

--- a/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
+++ b/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
@@ -5,7 +5,6 @@ import { MdStar } from 'react-icons/md';
 interface BookmarkButtonProps {
   isActive: boolean;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-  disabled?: boolean;
   className?: string;
 }
 

--- a/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
+++ b/src/features/kakao-map/components/bookmark/BookmarkButton.tsx
@@ -1,0 +1,93 @@
+import { type FC } from 'react';
+
+import { MdStar } from 'react-icons/md';
+
+interface BookmarkButtonProps {
+  isActive: boolean;
+  onClick: () => void;
+  className?: string;
+}
+
+const BookmarkButton: FC<BookmarkButtonProps> = ({
+  isActive,
+  onClick,
+  className = '',
+}) => {
+  return (
+    <div className="relative inline-block group">
+      <button
+        onClick={onClick}
+        className={`
+          w-12 h-12 
+          bg-white 
+          rounded-full 
+          shadow-lg 
+          flex items-center justify-center 
+          hover:bg-gray-50 
+          active:bg-gray-100 
+          disabled:opacity-50 
+          disabled:cursor-not-allowed
+          transition-all duration-200
+          ${className}
+        `}
+        aria-label="즐겨찾기 필터"
+      >
+        {isActive ? (
+          <MdStar className="w-6 h-6 text-yellow" />
+        ) : (
+          <MdStar className="w-6 h-6 text-gray" />
+        )}
+      </button>
+
+      {/* 툴팁 */}
+      <div
+        className="
+        absolute 
+        bottom-full 
+        left-1/2 
+        transform 
+        -translate-x-1/2 
+        mb-2 
+        px-3 
+        py-1.5 
+        bg-gray-900 
+        text-white 
+        text-xs 
+        font-medium
+        rounded-md 
+        shadow-lg
+        opacity-0 
+        group-hover:opacity-100 
+        transition-opacity 
+        duration-200 
+        pointer-events-none
+        whitespace-nowrap
+        z-50
+        invisible
+        group-hover:visible
+      "
+      >
+        즐겨찾기
+        {/* 툴팁 화살표 */}
+        <div
+          className="
+          absolute 
+          top-full 
+          left-1/2 
+          transform 
+          -translate-x-1/2 
+          w-0 
+          h-0 
+          border-l-4 
+          border-r-4 
+          border-t-4 
+          border-transparent 
+          border-t-gray-900
+        "
+        />
+      </div>
+    </div>
+  );
+};
+
+export default BookmarkButton;

--- a/src/features/kakao-map/components/bookmark/BookmarkControlContainer.tsx
+++ b/src/features/kakao-map/components/bookmark/BookmarkControlContainer.tsx
@@ -1,14 +1,28 @@
 import type { FC } from 'react';
 
+import { useModalStore } from '@/shared/store';
+import { useIsLoggedIn } from '@/shared/store/userStore';
+
 import { useMapData } from '../../hooks/useMapData';
 import BookmarkButton from './BookmarkButton';
 
 export const BookmarkControlContainer: FC = () => {
   const { isBookmarkMode, toggleBookmarkMode } = useMapData();
+  const isLoggedIn = useIsLoggedIn();
+  const openModal = useModalStore(state => state.openModal);
+
+  const handleClick = () => {
+    if (!isLoggedIn) {
+      openModal('login');
+      return;
+    }
+
+    toggleBookmarkMode();
+  };
 
   return (
     <div className="absolute bottom-48 right-4 z-10">
-      <BookmarkButton isActive={isBookmarkMode} onClick={toggleBookmarkMode} />
+      <BookmarkButton isActive={isBookmarkMode} onClick={handleClick} />
     </div>
   );
 };

--- a/src/features/kakao-map/components/bookmark/BookmarkControlContainer.tsx
+++ b/src/features/kakao-map/components/bookmark/BookmarkControlContainer.tsx
@@ -1,0 +1,14 @@
+import type { FC } from 'react';
+
+import { useMapData } from '../../hooks/useMapData';
+import BookmarkButton from './BookmarkButton';
+
+export const BookmarkControlContainer: FC = () => {
+  const { isBookmarkMode, toggleBookmarkMode } = useMapData();
+
+  return (
+    <div className="absolute bottom-48 right-4 z-10">
+      <BookmarkButton isActive={isBookmarkMode} onClick={toggleBookmarkMode} />
+    </div>
+  );
+};

--- a/src/features/kakao-map/components/marker/FavoriteMarker.tsx
+++ b/src/features/kakao-map/components/marker/FavoriteMarker.tsx
@@ -1,0 +1,34 @@
+import type { FC } from 'react';
+
+import { MdStar } from 'react-icons/md';
+
+interface FavoriteMarkerProps {
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+const FavoriteMarker: FC<FavoriteMarkerProps> = ({
+  isSelected = false,
+  onClick,
+}) => {
+  return (
+    <div className="relative" onClick={onClick}>
+      <div
+        className={`
+          text-3xl
+          drop-shadow-lg
+          transition-transform duration-200
+          cursor-pointer
+          hover:scale-110
+          ${isSelected ? 'ring-4 ring-blue-300 rounded-full bg-white p-1' : ''}
+        `}
+      >
+        <div className="w-6 h-6 bg-primary rounded-full flex items-center justify-center shadow-md">
+          <MdStar className="w-5 h-5 text-white" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteMarker;

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -398,6 +398,15 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
     }
   }, [onCenterChange, handleSearch, updateSearchPosition]);
 
+  // 중복 제거: 즐겨찾기 모드일 때 일반 마커에서 즐겨찾기 매장은 제외
+const filteredStoresToRender = useMemo(() => {
+  if (bookmarkMode) {
+    const bookmarkIds = new Set(bookmarkStores.map(s => s.storeId));
+    return storesToRender.filter(store => !bookmarkIds.has(store.storeId));
+  }
+  return storesToRender;
+}, [storesToRender, bookmarkMode, bookmarkStores]);
+
   return (
     <>
       {/* 거리 기반 재검색 버튼 */}
@@ -421,7 +430,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         }}
       >
         {/* 매장 마커들 */}
-        {storesToRender.map(store => (
+        {filteredStoresToRender.map(store => (
           <CustomOverlayMap
             key={store.storeId}
             position={{ lat: store.latitude, lng: store.longitude }}

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -26,6 +26,7 @@ import { useToggleFavoriteMutation } from '../../hooks/useMapQueries';
 import type { Store } from '../../types/store';
 import ResponsiveManualSearchButton from '../ManualSearchButton';
 import BrandMarker from './BrandMarker';
+import FavoriteMarker from './FavoriteMarker';
 import { KeywordInfoWindow } from './KeywordInfoWindow';
 import { KeywordMarker } from './KeywordMarker';
 import MyMapMarker from './MyMapMarker';
@@ -90,6 +91,8 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   );
   const setSelectedStore = useMapStore(state => state.selectStore);
 
+  const { bookmarkMode, bookmarkStores } = useMapStore();
+
   // 마커에 사용할 store 배열 결정(mymap)
   // const storesToRender = isShared ? sharedStores : stores;
   // 마커에 사용할 store 배열 결정 (일반 매장 + 추천 매장)
@@ -115,7 +118,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         storesCount: stores.length,
         recommendedCount: recommendedStores.length,
         totalRenderCount: allStores.length,
-        stores: allStores
+        stores: allStores,
       });
     }
 
@@ -440,6 +443,22 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
             )}
           </CustomOverlayMap>
         ))}
+
+        {/* 즐겨찾기 마커 */}
+        {bookmarkMode &&
+          bookmarkStores.map(store => (
+            <CustomOverlayMap
+              key={`bookmark-${store.storeId}`}
+              position={{ lat: store.latitude, lng: store.longitude }}
+              yAnchor={1}
+              xAnchor={0.5}
+            >
+              <FavoriteMarker
+                isSelected={selectedStoreId === store.storeId}
+                onClick={() => handleMarkerClick(store)}
+              />
+            </CustomOverlayMap>
+          ))}
 
         {/* 스토어 상세 정보 인포윈도우 */}
         {infoWindowStore && (

--- a/src/features/kakao-map/components/marker/MyMapMarker.tsx
+++ b/src/features/kakao-map/components/marker/MyMapMarker.tsx
@@ -1,15 +1,9 @@
 import type { FC } from 'react';
 
-
-
-import { MYMAP_COLOR } from '@mymap/constants/mymapColor';
+import { MYMAP_COLOR_BG } from '@mymap/constants/mymapColor';
 import type { MarkerColor } from '@mymap/constants/mymapColor';
 import { useSharedMapStore } from '@mymap/store/SharedMapStore';
-import { MdStars } from 'react-icons/md';
-
-
-
-
+import { MdStar } from 'react-icons/md';
 
 interface MyMapMarkerProps {
   isSelected?: boolean;
@@ -19,14 +13,14 @@ interface MyMapMarkerProps {
 const MyMapMarker: FC<MyMapMarkerProps> = ({ isSelected = false, onClick }) => {
   const markerColor = useSharedMapStore(state => state.markerColor);
   const markerColorClass =
-    MYMAP_COLOR[markerColor as MarkerColor] ?? MYMAP_COLOR.RED;
+    MYMAP_COLOR_BG[markerColor as MarkerColor] ?? MYMAP_COLOR_BG.RED;
+  console.log(`즐겨찾기색: ${markerColorClass}`);
 
   return (
     <div className="relative" onClick={onClick}>
       <div
         className={`
           text-3xl
-          ${markerColorClass}
           drop-shadow-lg
           transition-transform duration-200
           cursor-pointer
@@ -34,7 +28,11 @@ const MyMapMarker: FC<MyMapMarkerProps> = ({ isSelected = false, onClick }) => {
           ${isSelected ? 'ring-4 ring-blue-300 rounded-full bg-white p-1' : ''}
         `}
       >
-        <MdStars />
+        <div
+          className={`w-6 h-6 rounded-full ${markerColorClass} flex items-center justify-center shadow-md`}
+        >
+          <MdStar className="w-4 h-4 text-white" />
+        </div>
       </div>
 
       {isSelected && (

--- a/src/features/kakao-map/hooks/useMapData.ts
+++ b/src/features/kakao-map/hooks/useMapData.ts
@@ -4,6 +4,7 @@ import type { GetNearbyStoresParams } from '../api/types';
 import { getRegionInfo } from '../constants/regions';
 import { useMapUIContext } from '../context/MapUIContext';
 import {
+  useBookmarkMode,
   useMapStore,
   useRecommendedStores,
   useShowRecommendedStores,
@@ -44,6 +45,8 @@ export const useMapData = () => {
   const setStoreDetail = useMapStore(state => state.setStoreDetail);
   const selectStore = useMapStore(state => state.selectStore);
   const getCurrentLocation = useMapStore(state => state.getCurrentLocation);
+  const isBookmarkMode = useBookmarkMode();
+  const toggleBookmarkMode = useMapStore(state => state.toggleBookmarkMode);
   const setMapCenter = useMapStore(state => state.setMapCenter);
   // 추천 매장 액션들 추가
   const fetchRecommendedStores = useMapStore(
@@ -72,18 +75,18 @@ export const useMapData = () => {
       // FilterTabs의 value를 백엔드 API의 category 값으로 매핑 (필터탭 label과 동일하게)
       // 새로운 14개 비즈니스 카테고리에 맞춤 (APP/기기는 지도에서 제외)
       const categoryMapping: Record<string, string> = {
-        '테마파크': '테마파크',
-        '워터파크/아쿠아리움': '워터파크/아쿠아리움', 
-        '액티비티': '액티비티',
-        '뷰티': '뷰티',
-        '건강': '건강',
-        '쇼핑': '쇼핑',
+        테마파크: '테마파크',
+        '워터파크/아쿠아리움': '워터파크/아쿠아리움',
+        액티비티: '액티비티',
+        뷰티: '뷰티',
+        건강: '건강',
+        쇼핑: '쇼핑',
         '생활/편의': '생활/편의',
         '베이커리/디저트': '베이커리/디저트',
-        '음식점': '음식점',
+        음식점: '음식점',
         '영화/미디어': '영화/미디어',
         '공연/전시': '공연/전시',
-        '교육': '교육',
+        교육: '교육',
         '여행/교통': '여행/교통',
         // 기존 호환성을 위한 매핑 (구 카테고리가 있을 수 있음)
         activity: '액티비티',
@@ -149,7 +152,7 @@ export const useMapData = () => {
         console.log('🏪 Store data updated from API:', {
           storesCount: storeListQuery.data.data?.length || 0,
           queryParams: storeListParams,
-          data: storeListQuery.data.data
+          data: storeListQuery.data.data,
         });
       }
       setStoresFromQuery(storeListQuery.data);
@@ -309,6 +312,8 @@ export const useMapData = () => {
     fetchNearbyStores,
     selectStore,
     getCurrentLocation,
+    isBookmarkMode,
+    toggleBookmarkMode,
     setMapCenter,
     toggleFavorite,
     // 추천 매장 액션들 추가

--- a/src/features/kakao-map/store/MapStore.ts
+++ b/src/features/kakao-map/store/MapStore.ts
@@ -1,3 +1,4 @@
+import { getBookmark } from '@kakao-map/api/mapApi';
 import { getRecommendedStores } from '@recommendation/api/recommendedStoresApi';
 import { create } from 'zustand';
 import { devtools, subscribeWithSelector } from 'zustand/middleware';
@@ -61,6 +62,7 @@ const initialState: MapStoreState = {
 
   // 즐겨찾기 모드
   bookmarkMode: false,
+  bookmarkStores: [],
 };
 
 /**
@@ -141,9 +143,21 @@ export const useMapStore = create<MapStoreState & MapStoreActions>()(
       },
 
       toggleBookmarkMode: () => {
-        set(state => ({ bookmarkMode: !state.bookmarkMode }));
+        const next = !get().bookmarkMode;
+        if (next) {
+          get().fetchBookmarkStores();
+        }
+        set({ bookmarkMode: next });
       },
 
+      fetchBookmarkStores: async () => {
+        try {
+          const stores = await getBookmark();
+          set({ bookmarkStores: stores });
+        } catch (e) {
+          console.error('즐겨찾기 매장 조회 실패:', e);
+        }
+      },
       /**
        * 지도 중심점 설정
        */
@@ -347,3 +361,7 @@ export const useRecommendedStores = () =>
 export const useShowRecommendedStores = () =>
   useMapStore(state => state.showRecommendedStores);
 export const useBookmarkMode = () => useMapStore(state => state.bookmarkMode);
+export const useBookmarkStores = () =>
+  useMapStore(state => state.bookmarkStores);
+export const useFetchBookmarkStores = () =>
+  useMapStore(state => state.fetchBookmarkStores);

--- a/src/features/kakao-map/store/MapStore.ts
+++ b/src/features/kakao-map/store/MapStore.ts
@@ -58,6 +58,9 @@ const initialState: MapStoreState = {
   currentFilters: {},
   lastFetchParams: null,
   lastFetchTime: null,
+
+  // 즐겨찾기 모드
+  bookmarkMode: false,
 };
 
 /**
@@ -127,6 +130,18 @@ export const useMapStore = create<MapStoreState & MapStoreActions>()(
             errors: { ...state.errors, location: errorMessage },
           }));
         }
+      },
+
+      /**
+       * 즐겨찾기
+       * @param center
+       */
+      setBookmarkMode: (mode: boolean) => {
+        set({ bookmarkMode: mode });
+      },
+
+      toggleBookmarkMode: () => {
+        set(state => ({ bookmarkMode: !state.bookmarkMode }));
       },
 
       /**
@@ -331,3 +346,4 @@ export const useRecommendedStores = () =>
   useMapStore(state => state.recommendedStores);
 export const useShowRecommendedStores = () =>
   useMapStore(state => state.showRecommendedStores);
+export const useBookmarkMode = () => useMapStore(state => state.bookmarkMode);

--- a/src/features/kakao-map/store/MapStore.ts
+++ b/src/features/kakao-map/store/MapStore.ts
@@ -1,4 +1,4 @@
-import { getBookmark } from '@kakao-map/api/mapApi';
+import { mapApi } from '@kakao-map/api/mapApi';
 import { getRecommendedStores } from '@recommendation/api/recommendedStoresApi';
 import { create } from 'zustand';
 import { devtools, subscribeWithSelector } from 'zustand/middleware';
@@ -152,7 +152,7 @@ export const useMapStore = create<MapStoreState & MapStoreActions>()(
 
       fetchBookmarkStores: async () => {
         try {
-          const stores = await getBookmark();
+          const stores = await mapApi.getBookmark();
           set({ bookmarkStores: stores });
         } catch (e) {
           console.error('즐겨찾기 매장 조회 실패:', e);

--- a/src/features/kakao-map/store/types.ts
+++ b/src/features/kakao-map/store/types.ts
@@ -2,6 +2,7 @@ import type {
   GetNearbyStoresParams,
   StoreDetail,
   StoreListResponse,
+  StoreSummary,
 } from '../api/types';
 import type { Store } from '../types/store';
 
@@ -55,6 +56,7 @@ export interface MapStoreState {
 
   // 즐겨찾기 상태
   bookmarkMode: boolean;
+  bookmarkStores: StoreSummary[];
 }
 
 export interface MapStoreActions {
@@ -97,4 +99,7 @@ export interface MapStoreActions {
 
   // 유틸리티
   reset: () => void;
+
+  //
+  fetchBookmarkStores: () => Promise<void>;
 }

--- a/src/features/kakao-map/store/types.ts
+++ b/src/features/kakao-map/store/types.ts
@@ -52,12 +52,19 @@ export interface MapStoreState {
     region?: string;
     searchQuery?: string;
   };
+
+  // 즐겨찾기 상태
+  bookmarkMode: boolean;
 }
 
 export interface MapStoreActions {
   // 위치 관련
   getCurrentLocation: () => Promise<void>;
   setMapCenter: (center: Position) => void;
+
+  // 즐겨찾기 관련
+  setBookmarkMode: (mode: boolean) => void;
+  toggleBookmarkMode: () => void;
 
   // 매장 데이터 관리 (React Query 연동)
   setStores: (stores: Store[]) => void;

--- a/src/features/mymap/constants/mymapColor.ts
+++ b/src/features/mymap/constants/mymapColor.ts
@@ -7,3 +7,11 @@ export const MYMAP_COLOR: Record<MarkerColor, string> = {
   GREEN: 'text-green',
   PURPLE: 'text-purple',
 };
+
+export const MYMAP_COLOR_BG: Record<MarkerColor, string> = {
+  RED: 'bg-red-star',
+  ORANGE: 'bg-orange-star',
+  YELLOW: 'bg-yellow-star',
+  GREEN: 'bg-green-star',
+  PURPLE: 'bg-purple-star',
+};

--- a/src/index.css
+++ b/src/index.css
@@ -201,6 +201,11 @@
   --bg-secondary-hover: #d6e7ff;
   --bg-gray: #b0b8c1;
   --bg-gray-hover: #f0f0f0;
+  --bg-red-star: #ff3b30;
+  --bg-orange-star: #ff9500;
+  --bg-yellow-star: #ffcc00;
+  --bg-green-star: #34c759;
+  --bg-purple-star: #7e22ce;
 
   /* Border Colors */
   --border-ghost: #f2f4f6;
@@ -462,6 +467,21 @@
   }
   .hover\:bg-gray-hover:hover {
     background-color: var(--bg-gray-hover);
+  }
+  .bg-red-star {
+    background-color: var(--bg-red-star);
+  }
+  .bg-orange-star {
+    background-color: var(--bg-orange-star);
+  }
+  .bg-yellow-star {
+    background-color: var(--bg-yellow-star);
+  }
+  .bg-green-star {
+    background-color: var(--bg-green-star);
+  }
+  .bg-purple-star {
+    background-color: var(--bg-purple-star);
   }
 
   /* Border Color Utilities */

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -8,6 +8,7 @@ import { LocationControlContainer } from '@kakao-map/components/location/Locatio
 import { MapUIProvider } from '@kakao-map/context/MapUIContext';
 import { useMapUIContext } from '@kakao-map/context/MapUIContext';
 import useKakaoLoader from '@kakao-map/hooks/useKakaoLoader';
+import { BookmarkControlContainer } from '@kakao-map/components/bookmark/BookmarkControlContainer';
 
 /**
  * 카카오 맵과 관련된 리소스를 로드하고, 지도 및 UI 컨트롤, 위치 제어, 하단 시트가 포함된 전체 지도 페이지를 렌더링합니다.
@@ -141,6 +142,7 @@ const MapContent = () => {
           mapCenterSetter={mapCenterSetterRef.current}
           onPlaceClick={handlePlaceClick}
         />
+        <BookmarkControlContainer/>
         <LocationControlContainer />
       </div>
 

--- a/src/shared/msw/handlers/map.ts
+++ b/src/shared/msw/handlers/map.ts
@@ -15,6 +15,7 @@ import type {
 } from '@kakao-map/api/types';
 import { HttpResponse, http } from 'msw';
 
+import { createErrorResponse } from '@/shared/utils/createErrorResponse';
 import { createResponse } from '@/shared/utils/createResponse';
 
 /**
@@ -244,6 +245,11 @@ export const mapHandlers = [
    * GET map/stores/bookmark
    */
   http.get(MAP_ENDPOINTS.GET_BOOKMARK, () => {
+    const shouldFail = false;
+    if (shouldFail) {
+      //실패시
+      return createErrorResponse('로그인된 유저가 아닙니다.', 404);
+    }
     // 즐겨찾기 storeId만 추출
     const favoriteStoreIds = Object.keys(MOCK_FAVORITES)
       .map(Number)

--- a/src/shared/msw/handlers/map.ts
+++ b/src/shared/msw/handlers/map.ts
@@ -1,9 +1,11 @@
+import { MAP_ENDPOINTS } from '@kakao-map/api/endpoints';
 import {
+  MOCK_FAVORITES,
   MOCK_STORES,
+  createMockCategoryBrandsResponse,
   createMockStoreDetailResponse,
   createMockStoreListResponse,
   createMockToggleFavoriteResponse,
-  createMockCategoryBrandsResponse,
 } from '@kakao-map/api/mockData';
 import type {
   CategoryBrandsResponse,
@@ -12,6 +14,8 @@ import type {
   ToggleFavoriteResponseType,
 } from '@kakao-map/api/types';
 import { HttpResponse, http } from 'msw';
+
+import { createResponse } from '@/shared/utils/createResponse';
 
 /**
  * 지도 관련 API의 MSW 핸들러들
@@ -226,12 +230,30 @@ export const mapHandlers = [
 
     const response: CategoryBrandsResponse =
       createMockCategoryBrandsResponse(categoryId);
-    
+
     // 404 처리 (해당 카테고리에 브랜드가 없는 경우)
     if (response.statusCode === 404) {
       return HttpResponse.json(response, { status: 404 });
     }
 
     return HttpResponse.json(response, { status: 200 });
+  }),
+
+  /**
+   * 즐겨찾기 조회 API 핸들러
+   * GET map/stores/bookmark
+   */
+  http.get(MAP_ENDPOINTS.GET_BOOKMARK, () => {
+    // 즐겨찾기 storeId만 추출
+    const favoriteStoreIds = Object.keys(MOCK_FAVORITES)
+      .map(Number)
+      .filter(id => MOCK_FAVORITES[id]);
+
+    // MOCK_STORES 중 즐겨찾기된 store만 필터링
+    const result = MOCK_STORES.filter(store =>
+      favoriteStoreIds.includes(store.storeId)
+    );
+
+    return createResponse(result, '제휴처 리스트 목록 api 성공');
   }),
 ];


### PR DESCRIPTION
[![UHYU-334](https://badgen.net/badge/JIRA/UHYU-334/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-334) ![Medium](https://badgen.net/badge/PR%20Size/Medium/yellow) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-334-favorite-toggle)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-334-favorite-toggle) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
1. 즐겨찾기 조회 MSW
- 엔드포인터
- MSW 핸들러 구현
- 즐겨찾기 api 구현

2. 즐겨찾기 버튼 구현 및 연동

3. mymap 마커 수정 (즐겨찾기와 통일성 있게)

# 현재 UI 캡처

|UI 제목1|
|:--:|
|![즐겨찾기 토글](https://github.com/user-attachments/assets/08d9e28d-2411-458c-beb1-74042c9f73fc)|

## 참고사항
현재 즐겨찾기 api가 구현 전이라 목데이터로 로컬로 확인이 가능한 상태입니다!

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-334]: https://u-hyu.atlassian.net/browse/UHYU-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지도 페이지에 즐겨찾기(북마크) 모드가 추가되어, 즐겨찾기한 매장만 따로 확인할 수 있습니다.
  * 즐겨찾기 모드를 켜고 끌 수 있는 전용 버튼이 지도 화면에 표시됩니다.
  * 즐겨찾기 매장은 별도의 마커로 지도에 구분되어 표시됩니다.
  * 즐겨찾기 매장 목록을 불러오는 API가 추가되었습니다.

* **스타일**
  * 별(즐겨찾기) 마커에 다양한 색상 배경이 추가되었습니다.

* **버그 수정**
  * 즐겨찾기 관련 API 및 모의 데이터가 정상 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->