### PR TITLE
[FIX][UHYU-67] 쿠키 읽기 제거 및 서버 API 호출로 대체

### DIFF
--- a/src/shared/components/AppInitializer.tsx
+++ b/src/shared/components/AppInitializer.tsx
@@ -1,10 +1,9 @@
 import { useEffect } from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { PATH } from '@/routes/path';
 
-import { useTabFocusAuth } from '@/shared/hooks/useTabFocusAuth';
 import { userStore } from '@/shared/store/userStore';
 import {
   initKeyboardHandler,
@@ -17,6 +16,7 @@ import {
 
 const AppInitializer = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const initAuthState = userStore(state => state.initAuthState);
 
   // 관리자 페이지에서는 사용자 정보 요청을 하지 않음
@@ -35,17 +35,78 @@ const AppInitializer = () => {
     );
   }
 
+  // 🔥 새로 추가: 인증 리다이렉트 처리
   useEffect(() => {
-    if (!isAdminPage) {
-      // 쿠키 체크 → 필요시에만 서버 호출
+    const handleAuthRedirect = async () => {
+      const currentPath = location.pathname;
+
+      // 서버에서 리다이렉트된 인증 관련 페이지들
+      const authRedirectPages: string[] = [PATH.EXTRA_INFO, PATH.HOME];
+
+      if (authRedirectPages.includes(currentPath)) {
+        console.log('🎉 인증 리다이렉트 감지 - 경로:', currentPath);
+
+        try {
+          // 서버 리다이렉트로 온 경우 로그인 완료 상태
+          await userStore.getState().userInfo();
+          console.log('✅ 로그인 상태 업데이트 완료');
+        } catch (error) {
+          console.error('❌ 로그인 상태 업데이트 실패:', error);
+          // 실패 시 홈으로 리다이렉트 (무한 루프 방지)
+          if (currentPath !== PATH.HOME) {
+            navigate(PATH.HOME);
+          }
+        }
+      }
+    };
+
+    handleAuthRedirect();
+  }, [location.pathname, navigate]);
+
+  // 🔥 수정: 탭 활성화 시 인증 상태 동기화
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        console.log('🔄 탭 활성화 - 인증 상태 체크');
+
+        const currentPath = location.pathname;
+        const { user, isAuthChecked } = userStore.getState();
+
+        const authPages: string[] = [PATH.EXTRA_INFO, PATH.HOME];
+        // 인증 관련 페이지에서는 무조건 유저 정보 재조회
+        if (authPages.includes(currentPath)) {
+          if (!user) {
+            userStore.getState().userInfo();
+          }
+          return;
+        }
+
+        // 일반 페이지에서는 기존 로직
+        if (isAuthChecked) {
+          userStore.getState().userInfo();
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () =>
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    const authRedirectPages: string[] = [PATH.EXTRA_INFO];
+    const isAuthRedirectPage = authRedirectPages.includes(location.pathname);
+
+    if (!isAdminPage && !isAuthRedirectPage) {
+      // 일반 페이지에서는 기존 방식으로 인증 체크
       initAuthState();
-    } else {
-      // 관리자 페이지에서는 인증 체크 건너뛰기
+    } else if (isAdminPage) {
       userStore.setState({ isAuthChecked: true, user: null });
     }
-  }, [isAdminPage]);
+    // 인증 리다이렉트 페이지는 위의 handleAuthRedirect에서 처리
+  }, [isAdminPage, location.pathname, initAuthState]);
 
-  useTabFocusAuth();
+  // useTabFocusAuth();
 
   // 뷰포트 높이 및 스크롤 복원 초기화 (모바일 최적화)
   useEffect(() => {


### PR DESCRIPTION
[![UHYU-67](https://badgen.net/badge/JIRA/UHYU-67/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-67) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-67-recommend-ui)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-67-recommend-ui) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-67]: https://u-hyu.atlassian.net/browse/UHYU-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 인증 리디렉션 페이지에서 로그인 상태를 자동으로 갱신하고, 실패 시 홈으로 이동하는 기능이 추가되었습니다.
  * 탭이 활성화될 때 인증 상태를 자동으로 동기화하는 기능이 도입되었습니다.

* **개선 사항**
  * 인증 초기화 로직이 인증 리디렉션 및 관리자 페이지에 맞춰 더욱 세분화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->