### PR TITLE
[BUG][UHYU-342] 제휴처 리스트 , 삭제 및 중복제거

### DIFF
--- a/src/features/benefit/utils/formatGradeDescriptions.tsx
+++ b/src/features/benefit/utils/formatGradeDescriptions.tsx
@@ -1,7 +1,7 @@
 export const formatGradeDescriptions = (text: string | null): string => {
   if (!text) return '';
 
-  const cleanedText = text.replace(/\\n|\n/g, ' ');
+  const cleanedText = text.replace(/\\n|\\\\n/g, '\n');
 
   const gradePattern = /,?\s*(VVIP|VIP|우수)\s*:\s*/g;
   const matches = [...cleanedText.matchAll(gradePattern)];
@@ -26,7 +26,10 @@ export const formatGradeDescriptions = (text: string | null): string => {
 
   for (let i = 0; i < parts.length; i += 2) {
     const grade = parts[i];
-    const description = parts[i + 1]?.trim() ?? '';
+    let description = parts[i + 1]?.trim() ?? '';
+
+    description = description.replace(/(?<!\n)([①-⑨])/g, '\n$1');
+
     result += `${grade}: ${description}\n`;
   }
 

--- a/src/features/benefit/utils/formatGradeDescriptions.tsx
+++ b/src/features/benefit/utils/formatGradeDescriptions.tsx
@@ -3,7 +3,7 @@ export const formatGradeDescriptions = (text: string | null): string => {
 
   const cleanedText = text.replace(/\\n|\n/g, ' ');
 
-  const gradePattern = /(VVIP|VIP|우수)\s*:\s*/g;
+  const gradePattern = /,?\s*(VVIP|VIP|우수)\s*:\s*/g;
   const matches = [...cleanedText.matchAll(gradePattern)];
   const parts: string[] = [];
 

--- a/src/features/benefit/utils/formatGradeDescriptions.tsx
+++ b/src/features/benefit/utils/formatGradeDescriptions.tsx
@@ -1,8 +1,10 @@
 export const formatGradeDescriptions = (text: string | null): string => {
   if (!text) return '';
 
+  // 줄바꿈 문자 정리
   const cleanedText = text.replace(/\\n|\\\\n/g, '\n');
 
+  // 등급 패턴 (콤마 앞도 허용)
   const gradePattern = /,?\s*(VVIP|VIP|우수)\s*:\s*/g;
   const matches = [...cleanedText.matchAll(gradePattern)];
   const parts: string[] = [];
@@ -13,7 +15,7 @@ export const formatGradeDescriptions = (text: string | null): string => {
     if (lastIndex < matchIndex) {
       parts.push(cleanedText.substring(lastIndex, matchIndex).trim());
     }
-    parts.push(match[1]);
+    parts.push(match[1]); // 등급 (VVIP|VIP|우수)
     lastIndex = matchIndex + match[0].length;
 
     const nextMatch = matches[index + 1];
@@ -26,22 +28,24 @@ export const formatGradeDescriptions = (text: string | null): string => {
 
   for (let i = 0; i < parts.length; i += 2) {
     const grade = parts[i];
-    let desc = parts[i + 1]?.trim() ?? '';
-    desc = desc.replace(/(?<!\n)([①-⑨])/g, '\n$1'); // 줄바꿈
-    gradeMap.set(grade, desc);
+    let description = parts[i + 1]?.trim() ?? '';
+
+    description = description.replace(/(?<!\n)([②-⑨])/g, '\n$1');
+
+    gradeMap.set(grade, description);
   }
 
-  const allDescriptions = Array.from(gradeMap.values());
+  const uniqueDescriptions = new Set(gradeMap.values());
 
-  const allSame = allDescriptions.every(desc => desc === allDescriptions[0]);
-
-  if (allSame && allDescriptions.length > 0) {
-    return allDescriptions[0].trim();
+  // 모든 등급이 동일한 혜택이면 하나만 보여주기
+  if (uniqueDescriptions.size === 1) {
+    return `${[...uniqueDescriptions][0]}`;
   }
 
+  // 각 등급별 혜택 출력
   let result = '';
-  for (const [grade, desc] of gradeMap.entries()) {
-    result += `${grade}\n${desc.trim()}\n`;
+  for (const [grade, description] of gradeMap.entries()) {
+    result += `${grade}: ${description}\n`;
   }
 
   return result.trim();

--- a/src/features/benefit/utils/formatGradeDescriptions.tsx
+++ b/src/features/benefit/utils/formatGradeDescriptions.tsx
@@ -22,15 +22,26 @@ export const formatGradeDescriptions = (text: string | null): string => {
     lastIndex = endIndex;
   });
 
-  let result = '';
+  const gradeMap = new Map<string, string>();
 
   for (let i = 0; i < parts.length; i += 2) {
     const grade = parts[i];
-    let description = parts[i + 1]?.trim() ?? '';
+    let desc = parts[i + 1]?.trim() ?? '';
+    desc = desc.replace(/(?<!\n)([①-⑨])/g, '\n$1'); // 줄바꿈
+    gradeMap.set(grade, desc);
+  }
 
-    description = description.replace(/(?<!\n)([①-⑨])/g, '\n$1');
+  const allDescriptions = Array.from(gradeMap.values());
 
-    result += `${grade}: ${description}\n`;
+  const allSame = allDescriptions.every(desc => desc === allDescriptions[0]);
+
+  if (allSame && allDescriptions.length > 0) {
+    return allDescriptions[0].trim();
+  }
+
+  let result = '';
+  for (const [grade, desc] of gradeMap.entries()) {
+    result += `${grade}\n${desc.trim()}\n`;
   }
 
   return result.trim();

--- a/src/features/benefit/utils/formatGradeDescriptions.tsx
+++ b/src/features/benefit/utils/formatGradeDescriptions.tsx
@@ -1,8 +1,11 @@
 export const formatGradeDescriptions = (text: string | null): string => {
   if (!text) return '';
 
-  // 줄바꿈 문자 정리
-  const cleanedText = text.replace(/\\n|\\\\n/g, '\n');
+  // 줄바꿈 문자 및 백슬래시 정리
+  const cleanedText = text
+    .replace(/\\n|\\\\n/g, '\n') // \n → 실제 줄바꿈으로
+
+    .replace(/\\(?!n)/g, '\n'); // 나머지 \ → 제거 (예: "\t", "\a" 등 불필요한 이스케이프)
 
   // 등급 패턴 (콤마 앞도 허용)
   const gradePattern = /,?\s*(VVIP|VIP|우수)\s*:\s*/g;
@@ -30,6 +33,7 @@ export const formatGradeDescriptions = (text: string | null): string => {
     const grade = parts[i];
     let description = parts[i + 1]?.trim() ?? '';
 
+    // '②'~'⑨' 앞에 줄바꿈 추가 (이미 \n 있으면 그대로)
     description = description.replace(/(?<!\n)([②-⑨])/g, '\n$1');
 
     gradeMap.set(grade, description);


### PR DESCRIPTION
[![UHYU-326](https://badgen.net/badge/JIRA/UHYU-326/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-326) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-326-benefit-detail)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-326-benefit-detail) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
제휴처 리스트 혜택 정보를 , 삭제 및 중복제거하였습니다.

# 현재 UI 캡처

|수정 전|수정 후|
|:--:|:--:
|<img width="344" height="740" alt="스크린샷 2025-08-01 오후 4 17 47" src="https://github.com/user-attachments/assets/3f6a689e-4de4-40dc-a058-2146faf97fda" />|<img width="344" height="740" alt="스크린샷 2025-08-01 오후 4 32 59" src="https://github.com/user-attachments/assets/532f5edf-6241-4c5b-b212-8855e4bd5c3c" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-326]: https://u-hyu.atlassian.net/browse/UHYU-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 등급 설명 텍스트에서 줄바꿈 처리와 등급 라벨 인식이 개선되었습니다.
  * 등급별 설명이 모두 동일할 경우, 등급 라벨 없이 하나의 설명만 표시됩니다.
  * 특정 번호 기호(②-⑨) 앞에 자동으로 줄바꿈이 추가되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->