### PR TITLE
[FIX][UHYU-67] userInfo 메서드에서 hasValidAuthCookie() 체크 삭제

### DIFF
--- a/src/shared/store/userStore.ts
+++ b/src/shared/store/userStore.ts
@@ -5,7 +5,6 @@ import { create } from 'zustand';
 
 import type { ApiError } from '@/shared/client/client.type';
 import type { SimpleUserInfo } from '@/shared/types';
-import { hasValidAuthCookie } from '@/shared/utils/cookieAuthUtils';
 
 interface UserState {
   user: SimpleUserInfo | null;
@@ -22,14 +21,12 @@ export const userStore = create<UserState>(set => ({
   isAuthChecked: false,
   // 쿠키 기반 초기 인증 상태 확인
   initAuthState: async () => {
-    const hasCookie = hasValidAuthCookie();
-
-    if (hasCookie) {
-      // 쿠키가 있으면 서버에서 사용자 정보 조회
+    try {
+      // HttpOnly 쿠키는 체크할 수 없으므로 바로 서버에 요청
       await userStore.getState().userInfo();
-    } else {
-      // 쿠키가 없으면 바로 미인증 상태로 설정
-      set({ isAuthChecked: true, user: null });
+    } catch {
+      console.log('초기 인증 상태 확인 완료 (에러 발생)');
+      // userInfo에서 이미 에러 처리됨
     }
   },
   setUser: user => set({ user, isAuthChecked: true }),
@@ -46,13 +43,11 @@ export const userStore = create<UserState>(set => ({
   },
   userInfo: async () => {
     try {
-      // 쿠키가 없다면 서버 호출하지 않음
-      if (!hasValidAuthCookie()) {
-        userStore.getState().clearUser();
-        return;
-      }
-
       const res = await userApi.getUserInfo();
+      console.log('📡 서버 응답:', {
+        statusCode: res.statusCode,
+        data: res.data,
+      });
 
       if ((res.statusCode === 200 || res.statusCode === 0) && res.data) {
         const { userName, grade, profileImage, role } = res.data;


### PR DESCRIPTION
[![UHYU-67](https://badgen.net/badge/JIRA/UHYU-67/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-67) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-67-recommend-ui)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-67-recommend-ui) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-67]: https://u-hyu.atlassian.net/browse/UHYU-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인증 상태 초기화 및 사용자 정보 요청 시, 쿠키 유효성 검사 없이 서버 응답만을 기반으로 처리하도록 개선되었습니다.  
  * 사용자 정보 요청 과정에서 오류 발생 시 사용자 상태가 적절히 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->