### PR TITLE
[FEAT][UHYU-327] My Map 지도 조회 (UUID 기반,비회원) MSW 및 공유지도 비회원 조회 구현

### DIFF
--- a/src/features/mymap/api/endpoint.ts
+++ b/src/features/mymap/api/endpoint.ts
@@ -9,6 +9,8 @@ export const MYMAP_ENDPOINTS = {
       `/mymap/${myMapListId}`,
     VIEW: (uuid: string) => `/mymap/${uuid}`,
     VIEW_MSW: (uuid: string = ':uuid') => `/mymap/${uuid}`,
+    GUEST_VIEW: (uuid: string) => `/guest/mymap/${uuid}`,
+    GUEST_VIEW_MSW: (uuid: string = ':uuid') => `/guest/mymap/${uuid}`,
     STATE: (store_id: number) => `/mymap/list/${store_id}`,
     STATE_MSW: (store_id: number | string = ':store_id') =>
       `/mymap/list/${store_id}`,

--- a/src/features/mymap/api/mymapApi.ts
+++ b/src/features/mymap/api/mymapApi.ts
@@ -110,3 +110,17 @@ export const getMyMapUuid = async (uuid: string): Promise<MymapUuidRes> => {
   }
   return res.data.data;
 };
+
+// My Map 상세 조회 API (UUID 기반, 비회원)
+export const getMyMapUuidGuest = async (
+  uuid: string
+): Promise<MymapUuidRes> => {
+  const res = await client.get<ApiResponse<MymapUuidRes>>(
+    MYMAP_ENDPOINTS.MYMAP.GUEST_VIEW(uuid)
+  );
+
+  if (!res.data.data) {
+    throw new Error('My Map 상세 데이터를 불러올 수 없습니다');
+  }
+  return res.data.data;
+};

--- a/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
+++ b/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import type { Store } from '@mymap/api/types';
 import { ShareModal, StoreDeleteModal } from '@mymap/components';
 import { MYMAP_COLOR, type MarkerColor } from '@mymap/constants/mymapColor';
-import { useMyMapUuidQuery } from '@mymap/hooks';
+import { useMyMapUuidGuestQuery, useMyMapUuidQuery } from '@mymap/hooks';
 import { useSharedMapStore } from '@mymap/store/SharedMapStore';
 import { MdIosShare, MdStars } from 'react-icons/md';
 import { PiTrashBold } from 'react-icons/pi';
@@ -13,6 +13,7 @@ import { BrandCard } from '@/shared/components';
 import { BackButton } from '@/shared/components';
 import { SkeletonMyMapUuidItem } from '@/shared/components/skeleton';
 import { useModalStore } from '@/shared/store';
+import { useIsLoggedIn } from '@/shared/store/userStore';
 
 interface MyMapUuidProps {
   uuid: string;
@@ -21,7 +22,15 @@ interface MyMapUuidProps {
 
 const MyMapUuid = ({ uuid, onStoreClick }: MyMapUuidProps) => {
   const navigate = useNavigate();
-  const { data, isPending, isError } = useMyMapUuidQuery(uuid);
+  const isLoggedIn = useIsLoggedIn();
+  const resultAuth = useMyMapUuidQuery(uuid, isLoggedIn);
+  const resultGuest = useMyMapUuidGuestQuery(uuid, !isLoggedIn);
+  console.log(`로그인상태: ${isLoggedIn}`);
+
+  const data = isLoggedIn ? resultAuth.data : resultGuest.data;
+  const isPending = isLoggedIn ? resultAuth.isPending : resultGuest.isPending;
+  const isError = isLoggedIn ? resultAuth.isError : resultGuest.isError;
+
   const openModal = useModalStore(state => state.openModal);
   const { stores, title, markerColor, isMine, setSharedMap } =
     useSharedMapStore();

--- a/src/features/mymap/hooks/index.ts
+++ b/src/features/mymap/hooks/index.ts
@@ -4,6 +4,7 @@ export { useInitSharedMap } from './useInitSharedMap';
 export { useKakaoShare } from './useKakaoShare';
 export { useMyMapListQuery } from './useMyMapListQuery';
 export { useMyMapUuidQuery } from './useMyMapUuidQuery';
+export { useMyMapUuidGuestQuery } from './useMyMapUuidQuery';
 export { useStoreBookmarkStatusQuery } from './useStoreBookmarkStatusQuery';
 export { useToggleMyMapStoreMutation } from './useToggleMyMapStoreMutation';
 export { useUpdateMyMapMutation } from './useUpdateMyMapMutation';

--- a/src/features/mymap/hooks/useMyMapUuidQuery.ts
+++ b/src/features/mymap/hooks/useMyMapUuidQuery.ts
@@ -1,20 +1,32 @@
-import { getMyMapUuid } from '@mymap/api/mymapApi';
+import { getMyMapUuid, getMyMapUuidGuest } from '@mymap/api/mymapApi';
 import type { MymapUuidRes } from '@mymap/api/types';
 import { useQuery } from '@tanstack/react-query';
 
 export const MYMAP_QUERY_KEYS = {
-  detail: (uuid: string) => ['mymap-detail', uuid] as const,
+  detail: (uuid: string) => ['mymap-detail', 'auth', uuid] as const,
+  guestDetail: (uuid: string) => ['mymap-detail', 'guest', uuid] as const,
 };
 
 /**
- * My Map 상세 조회 (UUID 기반) Query 훅
- * @param uuid
- * @param enabled
+ * My Map 공유지도 조회 (UUID 기반, 로그인)
  */
 export const useMyMapUuidQuery = (uuid: string, enabled = true) => {
   return useQuery<MymapUuidRes>({
     queryKey: MYMAP_QUERY_KEYS.detail(uuid),
     queryFn: () => getMyMapUuid(uuid),
+    enabled: !!uuid && enabled,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+};
+
+/**
+ * My Map 공유지도 조회 (UUID 기반, 비회원)
+ */
+export const useMyMapUuidGuestQuery = (uuid: string, enabled = true) => {
+  return useQuery<MymapUuidRes>({
+    queryKey: MYMAP_QUERY_KEYS.guestDetail(uuid),
+    queryFn: () => getMyMapUuidGuest(uuid),
     enabled: !!uuid && enabled,
     staleTime: 5 * 60 * 1000,
     retry: 1,

--- a/src/shared/msw/handlers/mymap.ts
+++ b/src/shared/msw/handlers/mymap.ts
@@ -162,4 +162,23 @@ export const mymapHandlers = [
 
     return createErrorResponse('해당 UUID의 마이맵이 존재하지 않습니다.', 404);
   }),
+
+  // My Map 지도 조회 (UUID 기반, 비회원)
+  http.get(MYMAP_ENDPOINTS.MYMAP.GUEST_VIEW_MSW(), async ({ params }) => {
+    const uuid = params.uuid;
+    console.log(params.uuid);
+
+    if (!uuid) {
+      return createErrorResponse('UUID가 없습니다.', 400);
+    }
+
+    if (uuid === MOCK_MYMAP_DATA_BY_UUID.uuid) {
+      return createResponse(
+        MOCK_MYMAP_DATA_BY_UUID,
+        '마이맵 상세 불러오기 성공'
+      );
+    }
+
+    return createErrorResponse('해당 UUID의 마이맵이 존재하지 않습니다.', 404);
+  }),
 ];


### PR DESCRIPTION
[![UHYU-327](https://badgen.net/badge/JIRA/UHYU-327/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-327) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-327-sharemap)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-327-sharemap) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
1. My Map 지도 조회 (UUID 기반,비회원) MSW
- endpoint
- MSW
- api
- 훅

2. 공유지도 비회원 조회 구현
- 로그인 분기처리

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-327]: https://u-hyu.atlassian.net/browse/UHYU-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 비회원(게스트) 사용자가 My Map을 UUID로 조회할 수 있는 기능이 추가되었습니다.
  * 게스트 전용 조회 API가 도입되어, 로그인 여부에 따라 지도 상세 정보를 각각의 방식으로 불러옵니다.

* **버그 수정**
  * 없음

* **기타**
  * 게스트 조회 기능을 위한 목(Mock) 데이터 핸들러가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->