### PR TITLE
[BUG][UHYU-350] 공유지도 바텀시트 중간 위치로 수정

### DIFF
--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback } from 'react';
+import { forwardRef, useCallback, useEffect } from 'react';
 
 import { MyMapList, MymapUuid } from '@mymap/components';
 import { FaFilter } from 'react-icons/fa';
@@ -46,6 +46,15 @@ export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
     const { uuid } = useParams();
 
     const isShared = !!uuid;
+
+    // 공유지도일 때 중간 바텀시트
+    useEffect(() => {
+      if (isShared && bottomSheetRef?.current) {
+        setTimeout(() => {
+          bottomSheetRef.current?.openMiddle();
+        }, 0);
+      }
+    }, [isShared, bottomSheetRef]);
 
     // 브랜드 단계일 때만 브랜드 데이터 조회 (성능 최적화)
     const { brands, isLoading: brandsLoading } = useBrandsByCategoryWhen(

--- a/src/features/kakao-map/components/MapDragBottomSheet.tsx
+++ b/src/features/kakao-map/components/MapDragBottomSheet.tsx
@@ -17,6 +17,7 @@ interface MapDragBottomSheetProps {
 export interface MapDragBottomSheetRef {
   close: () => void; // 닫기
   open: () => void; // 열기
+  openMiddle: () => void; // 중간 열기
   toggle: () => void; // 토글
   initialize: () => void; // 최초 한 번만 열림
   setExplicitlyClosed: (closed: boolean) => void; // 외부에서 명시적으로 닫힘 상태 설정
@@ -92,6 +93,7 @@ export const MapDragBottomSheet = forwardRef<
   // 기본 위치 정의 (스냅용) - 패딩된 컨테이너 기준
   const openY = CONSTANTS.EXPANDED_BOTTOM_MARGIN; // 열린 상태 기본 위치
   const closedY = availableHeight - dynamicHandleHeight; // 닫힌 상태: 핸들이 네비게이션 바로 위에 위치
+  const middleY = availableHeight * 0.4; // 열린 중간 상태 기본 위치
 
   // 🎬 CSS transform을 통한 위치 제어
   const [translateY, setTranslateY] = useState(closedY);
@@ -120,6 +122,10 @@ export const MapDragBottomSheet = forwardRef<
         setIsOpen(true);
         animateToPosition(openY);
       },
+      openMiddle: () => {
+        setIsOpen(true);
+        animateToPosition(middleY);
+      },
       toggle: () => {
         if (isOpen) {
           setIsOpen(false);
@@ -143,7 +149,7 @@ export const MapDragBottomSheet = forwardRef<
       },
       getCurrentPosition: () => translateY,
     }),
-    [translateY, openY, closedY, isOpen, animateToPosition]
+    [translateY, openY, closedY, middleY, isOpen, animateToPosition]
   );
 
   // translateY 초기화


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
공유지도 바텀시트 중간 위치로 수정

1. openMiddle 메서드 추가
2. 공유지도에서 중간 위치로 바텀시트 열림 적용

# 현재 UI 캡처

|이전전 UI|이후 UI|
|:--:|:--:|
|<img width="343" height="743" alt="스크린샷 2025-08-01 오후 11 51 43" src="https://github.com/user-attachments/assets/2224f1cc-43ff-4a13-8fc3-db874bb0fa00" />|![수정](https://github.com/user-attachments/assets/d1d5245e-b1d6-4487-9caa-8427a6893953)|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
