### PR TITLE
[BUG][UHYU-358] MapControlsContainer의 위치 기준을 MapContent로 변경

### DIFF
--- a/src/features/kakao-map/components/controls/MapControlsContainer.tsx
+++ b/src/features/kakao-map/components/controls/MapControlsContainer.tsx
@@ -9,7 +9,7 @@ import { LocationControlContainer } from '../location/LocationControlContainer';
  */
 export const MapControlsContainer: FC = () => {
   return (
-    <div className="fixed right-4 bottom-[7rem] z-40 flex flex-col gap-3 md:right-6">
+    <div className="absolute right-4 bottom-[7rem] z-40 flex flex-col gap-3 md:right-6">
       {/* 북마크 버튼 (상단) */}
       <BookmarkControlContainer />
       


### PR DESCRIPTION
[![UHYU-358](https://badgen.net/badge/JIRA/UHYU-358/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-358) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=BUG/UHYU-358-MapControlsContainer-update)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:BUG/UHYU-358-MapControlsContainer-update) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
MapControlsContainer의 위치 기준을 MapContent로 변경

# 현재 UI 캡처

|수정 전UI|수정 후UI|
|:--:|:--:|
|<img width="1470" height="832" alt="스크린샷 2025-08-02 오후 5 46 51" src="https://github.com/user-attachments/assets/5ad93e31-1014-4801-9b8d-64cb96fd9cdf" />|<img width="1470" height="836" alt="스크린샷 2025-08-02 오후 6 18 53" src="https://github.com/user-attachments/assets/933fbe8b-c102-4293-a1df-5dd7aab9804c" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-358]: https://u-hyu.atlassian.net/browse/UHYU-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 지도 컨트롤 버튼의 위치 지정 방식이 변경되어, 컨테이너가 이제 상위 요소 기준으로 배치됩니다. (fixed → absolute)  
  * 사용자에게 보이는 위치와 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->