### PR TITLE
[HOTFIX] user 로컬스토리지 저장에서 세션스토리지 저장으로 변경

### DIFF
--- a/src/shared/store/userStore.ts
+++ b/src/shared/store/userStore.ts
@@ -2,14 +2,15 @@ import { userApi } from '@user/index';
 import type { AxiosError } from 'axios';
 import { toast } from 'sonner';
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type { ApiError } from '@/shared/client/client.type';
 import type { SimpleUserInfo } from '@/shared/types';
 
 interface UserState {
   user: SimpleUserInfo | null;
-  isAuthChecked: boolean; // 유저가 로그인 되어있는지 ㅊㅔ크
+  isAuthChecked: boolean; // 유저가 로그인 되어있는지 체크
+  initAuthState: () => Promise<void>;
   setUser: (user: SimpleUserInfo) => void;
   clearUser: () => void;
   logout: () => Promise<void>;
@@ -18,40 +19,73 @@ interface UserState {
 
 export const userStore = create<UserState>()(
   persist(
-    set => ({
+    (set, get) => ({
       user: null,
       isAuthChecked: false,
+
+      // 쿠키 기반 초기 인증 상태 확인
+      initAuthState: async () => {
+        try {
+          // sessionStorage에 사용자 정보가 있으면 서버에서 검증
+          const storedUser = get().user;
+          if (storedUser) {
+            console.log(
+              '📦 sessionStorage에서 사용자 정보 발견 - 서버 검증 시작'
+            );
+            await get().userInfo();
+          } else {
+            // HttpOnly 쿠키는 체크할 수 없으므로 바로 서버에 요청
+            console.log('🔍 초기 인증 상태 확인 시작');
+            await get().userInfo();
+          }
+        } catch {
+          console.log('초기 인증 상태 확인 완료 (에러 발생)');
+          // userInfo에서 이미 에러 처리됨
+        }
+      },
+
       setUser: user => set({ user, isAuthChecked: true }),
-      clearUser: () => set({ user: null, isAuthChecked: true }),
+
+      clearUser: () => {
+        set({ user: null, isAuthChecked: true });
+        // sessionStorage에서도 완전히 제거
+        sessionStorage.removeItem('user-storage');
+      },
+
       logout: async () => {
         try {
           const res = await userApi.logout();
-          userStore.getState().clearUser();
-          localStorage.removeItem('user-storage');
+          get().clearUser(); // clearUser 호출로 sessionStorage도 함께 정리
           toast.info(res.message);
         } catch (error) {
           toast.error('❌ 로그아웃 실패했습니다. 다시 시도해주세요');
           throw error;
         }
       },
+
       userInfo: async () => {
         try {
           const res = await userApi.getUserInfo();
+          console.log('📡 서버 응답:', {
+            statusCode: res.statusCode,
+            data: res.data,
+          });
 
           if ((res.statusCode === 200 || res.statusCode === 0) && res.data) {
             const { userName, grade, profileImage, role } = res.data;
-            userStore
-              .getState()
-              .setUser({ userName, grade, profileImage, role });
+            get().setUser({ userName, grade, profileImage, role });
           } else {
-            userStore.getState().clearUser();
+            console.warn('⚠️ 유저 정보 조회 실패: 응답 데이터 없음', res);
+            get().clearUser();
           }
         } catch (error: unknown) {
-          console.error('❌ [userInfo] 요청 실패:', error);
           const err = error as AxiosError<ApiError>;
+          // 401이면 clearUser(), 그 외 에러는 유지
           if (err.response?.data?.statusCode === 401) {
-            userStore.getState().clearUser();
+            console.log('🔐 401 에러 - 인증 만료로 로그아웃 처리');
+            get().clearUser();
           } else {
+            console.warn('⚠️ 유저 정보 조회 실패(비401): 상태 유지', err);
             set({ isAuthChecked: true });
           }
         }
@@ -59,6 +93,8 @@ export const userStore = create<UserState>()(
     }),
     {
       name: 'user-storage',
+      // sessionStorage 사용 (브라우저 탭 닫으면 자동 삭제)
+      storage: createJSONStorage(() => sessionStorage),
       // 저장할 state만 선택
       partialize: state => ({
         user: state.user,
@@ -66,8 +102,11 @@ export const userStore = create<UserState>()(
       }),
       onRehydrateStorage: () => state => {
         if (state) {
+          // 복원된 상태가 있으면 서버에서 재검증 필요
+          console.log('🔄 sessionStorage에서 사용자 상태 복원됨');
           userStore.setState({ isAuthChecked: true });
         } else {
+          // 복원할 데이터가 없으면 인증 확인 완료로 설정
           userStore.setState({ isAuthChecked: true, user: null });
         }
       },
@@ -78,6 +117,14 @@ export const userStore = create<UserState>()(
 export const useIsLoggedIn = () => {
   const user = userStore(state => state.user);
   const isAuthChecked = userStore(state => state.isAuthChecked);
+
+  // 관리자 페이지에서는 유저 정보 로깅하지 않음
+  if (import.meta.env.DEV && typeof window !== 'undefined') {
+    const isAdminPage = window.location.pathname === '/admin';
+    if (!isAdminPage) {
+      console.log('user', user);
+    }
+  }
 
   // 인증 확인이 완료되지 않았다면 false 반환 (초기 로딩 중)
   if (!isAuthChecked) {


### PR DESCRIPTION
[![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=hotfix/login)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:hotfix/login) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
기존 persist를 이용해서 로컬스토리지에 저장하다보니 
저장하고 들어와도 쿠키가 없는 상태인데 로그인이 유지되고 있던 버그 수정

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 인증 상태 초기화 및 세션 저장소 동기화가 개선되었습니다.
  * 로그아웃 시 사용자 정보가 세션 저장소에서 올바르게 삭제됩니다.
  * 서버 인증 정보 확인 시 오류 처리 및 로그가 강화되었습니다.

* **스타일**
  * 코드 스타일과 주석이 일부 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->