### PR TITLE
[REFACTOR][UHYU-355] bacode modal 수정

### DIFF
--- a/src/shared/components/BaseLayout.tsx
+++ b/src/shared/components/BaseLayout.tsx
@@ -6,6 +6,7 @@ interface BaseLayoutProps {
 const BaseLayout = ({ children, isMap = false }: BaseLayoutProps) => {
   return (
     <div
+      id="main-content"
       className={
         isMap
           ? 'flex-1 bg-white w-full h-full min-w-0 desktop-padding'

--- a/src/shared/components/bottom_navigation/BottomNavigation.tsx
+++ b/src/shared/components/bottom_navigation/BottomNavigation.tsx
@@ -1,9 +1,6 @@
-import { useState } from 'react';
-
 import { PATH } from '@paths';
 import { X } from 'lucide-react';
-import { FaMap } from 'react-icons/fa';
-import { FaMapMarkerAlt } from 'react-icons/fa';
+import { FaMap, FaMapMarkerAlt } from 'react-icons/fa';
 import { FaUser } from 'react-icons/fa6';
 import { HiGift } from 'react-icons/hi';
 import { LiaBarcodeSolid } from 'react-icons/lia';
@@ -12,15 +9,16 @@ import { NavLink, useLocation } from 'react-router-dom';
 import BarcodeItem from '@/shared/components/bottom_navigation/BarcodeItem';
 import NavItem from '@/shared/components/bottom_navigation/NavItem';
 import { useAuthCheckModal } from '@/shared/hooks/useAuthCheckModal';
+import { useBarcodeStore } from '@/shared/store/barcodeStore';
 import { useUser } from '@/shared/store/userStore';
 
 import { BarcodeBottomSheet } from './barcode/BarcodeBottomSheet';
 
 const BottomNavigation = () => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
   const { checkAuthAndExecuteModal, isLoggedIn } = useAuthCheckModal();
   const location = useLocation();
   const user = useUser();
+  const { isOpen, open, close } = useBarcodeStore();
 
   // URL 기반으로 활성 탭 결정
   const getActiveTab = (pathname: string) => {
@@ -36,12 +34,6 @@ const BottomNavigation = () => {
 
   const activeTab = getActiveTab(location.pathname);
 
-  const handleBarcodeClick = () => {
-    checkAuthAndExecuteModal(() => {
-      setIsOpen(prev => !prev);
-    });
-  };
-
   const handleMyPageClick = (e?: React.MouseEvent) => {
     if (!isLoggedIn) {
       e?.preventDefault();
@@ -54,6 +46,10 @@ const BottomNavigation = () => {
       e?.preventDefault();
       checkAuthAndExecuteModal(() => {});
     }
+  };
+
+  const handleBarcodeClick = () => {
+    return isOpen ? close() : open();
   };
 
   return (
@@ -127,10 +123,7 @@ const BottomNavigation = () => {
         )}
       </nav>
       <div className="absolute bottom-full w-full">
-        <BarcodeBottomSheet
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-        ></BarcodeBottomSheet>
+        <BarcodeBottomSheet />
       </div>
     </div>
   );

--- a/src/shared/components/bottom_navigation/barcode/BarcodeBottomSheet.tsx
+++ b/src/shared/components/bottom_navigation/barcode/BarcodeBottomSheet.tsx
@@ -1,6 +1,7 @@
-import { type FC, useEffect } from 'react';
+import { type FC, useEffect, useState } from 'react';
 
 import { X } from 'lucide-react';
+import { createPortal } from 'react-dom';
 
 import {
   GuestBarcodeContent,
@@ -19,6 +20,21 @@ export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
 }) => {
   const isLoggedIn = useIsLoggedIn();
   const user = useUser();
+  const [mainContentElement, setMainContentElement] =
+    useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // main-content 엘리먼트 찾기
+    const element = document.getElementById('main-content');
+    if (element) {
+      setMainContentElement(element);
+      // relative positioning 확인 및 설정
+      const computedStyle = window.getComputedStyle(element);
+      if (computedStyle.position === 'static') {
+        element.style.position = 'relative';
+      }
+    }
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -29,42 +45,54 @@ export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !mainContentElement) return null;
 
-  return (
+  const modalContent = (
     <>
+      {/* 오버레이 - main-content 전체를 덮음 */}
       <div
         onClick={onClose}
         role="presentation"
-        className="fixed inset-0 bg-black/4"
+        className="absolute inset-0 bg-black/40 z-[50]"
       />
 
+      {/* 바텀시트 - main-content 하단에 고정 */}
       <div
         role="dialog"
         aria-label="바코드 바텀시트"
-        className="absolute bottom-[0.5px] left-0 right-0"
+        className="absolute bottom-0 left-0 right-0 z-[51] desktop-padding"
       >
-        <div className="bg-white rounded-t-2xl z-30 flex flex-col border border-light-gray p-4 min-h-[150px]">
-          <header className="flex justify-between items-center mb-4">
+        <div className="bg-white rounded-t-2xl border border-light-gray flex flex-col max-h-[70vh] shadow-lg">
+          {/* 핸들 */}
+          <div className="flex justify-center py-3 flex-shrink-0">
+            <div className="w-12 h-1.5 bg-gray-300 rounded-full" />
+          </div>
+
+          {/* 헤더 */}
+          <header className="flex justify-between items-center px-6 pb-4 flex-shrink-0">
             <h2 className="text-lg font-semibold flex-1">
               {user
                 ? `${user.userName} ${user.grade} 멤버십 바코드`
                 : '멤버십 바코드'}
             </h2>
-            <div className="flex gap-4">
-              <button
-                onClick={onClose}
-                aria-label="닫기"
-                className="cursor-pointer hover:bg-gray-200 rounded-md"
-              >
-                <X size={20} />
-              </button>
-            </div>
+            <button
+              onClick={onClose}
+              aria-label="닫기"
+              className="cursor-pointer hover:bg-gray-200 p-2 rounded-md transition-colors"
+            >
+              <X size={20} />
+            </button>
           </header>
 
-          {isLoggedIn ? <LoggedInBarcodeContent /> : <GuestBarcodeContent />}
+          {/* 컨텐츠 */}
+          <div className="flex-1 overflow-y-auto px-6 pb-6 min-h-0">
+            {isLoggedIn ? <LoggedInBarcodeContent /> : <GuestBarcodeContent />}
+          </div>
         </div>
       </div>
     </>
   );
+
+  // main-content 컨테이너에 포털로 렌더링
+  return createPortal(modalContent, mainContentElement);
 };

--- a/src/shared/components/bottom_navigation/barcode/BarcodeBottomSheet.tsx
+++ b/src/shared/components/bottom_navigation/barcode/BarcodeBottomSheet.tsx
@@ -85,7 +85,7 @@ export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
           </header>
 
           {/* 컨텐츠 */}
-          <div className="flex-1 overflow-y-auto px-6 pb-6 min-h-0">
+          <div className="flex-1 overflow-y-auto px-6 pb-10 min-h-0">
             {isLoggedIn ? <LoggedInBarcodeContent /> : <GuestBarcodeContent />}
           </div>
         </div>

--- a/src/shared/components/bottom_navigation/barcode/BarcodeBottomSheet.tsx
+++ b/src/shared/components/bottom_navigation/barcode/BarcodeBottomSheet.tsx
@@ -7,19 +7,13 @@ import {
   GuestBarcodeContent,
   LoggedInBarcodeContent,
 } from '@/shared/components/bottom_navigation/barcode/contents';
+import { useBarcodeStore } from '@/shared/store/barcodeStore';
 import { useIsLoggedIn, useUser } from '@/shared/store/userStore';
 
-interface BarcodeBottomSheetProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
-  isOpen,
-  onClose,
-}) => {
+export const BarcodeBottomSheet: FC = () => {
   const isLoggedIn = useIsLoggedIn();
   const user = useUser();
+  const { isOpen, close } = useBarcodeStore();
   const [mainContentElement, setMainContentElement] =
     useState<HTMLElement | null>(null);
 
@@ -38,12 +32,12 @@ export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') close();
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  }, [close]);
 
   if (!isOpen || !mainContentElement) return null;
 
@@ -51,7 +45,7 @@ export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
     <>
       {/* 오버레이 - main-content 전체를 덮음 */}
       <div
-        onClick={onClose}
+        onClick={close}
         role="presentation"
         className="absolute inset-0 bg-black/40 z-[50]"
       />
@@ -76,7 +70,7 @@ export const BarcodeBottomSheet: FC<BarcodeBottomSheetProps> = ({
                 : '멤버십 바코드'}
             </h2>
             <button
-              onClick={onClose}
+              onClick={close}
               aria-label="닫기"
               className="cursor-pointer hover:bg-gray-200 p-2 rounded-md transition-colors"
             >

--- a/src/shared/components/bottom_navigation/barcode/contents/GuestBarcodeContent.tsx
+++ b/src/shared/components/bottom_navigation/barcode/contents/GuestBarcodeContent.tsx
@@ -1,17 +1,12 @@
-import { NavButton } from '@/shared/components/buttons/NavButton';
+import { KakaoLoginButton } from '@/shared/components/buttons/KakaoLoginButton';
 
 export const GuestBarcodeContent = () => {
   return (
-    <div className="flex flex-col w-full gap-4">
+    <div className="flex flex-col w-full gap-4 pb-10">
       <p className="text-lg text-black">
         멤버십 바코드 기능은 로그인 후 이용하실 수 있어요.
       </p>
-      <NavButton
-        to={import.meta.env.VITE_KAKAO_LOGIN_URL}
-        className="w-full text-lg"
-      >
-        로그인 하러가기
-      </NavButton>
+      <KakaoLoginButton />
     </div>
   );
 };

--- a/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
+++ b/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import VisitConfirmSection from '@barcode/components/VisitConfirmSection';
 import { useBarcodeImageQuery } from '@barcode/hooks/useBarcodeImageQuery';
 import { useNearbyStoreQuery } from '@barcode/hooks/useNearbyStoreQuery';
+import { RefreshCcw } from 'lucide-react';
+import { BeatLoader } from 'react-spinners';
 
 import { PrimaryButton } from '@/shared/components';
 import { BarcodeCropModal } from '@/shared/components/bottom_navigation/barcode/BarcodeCropModal';
@@ -63,7 +65,7 @@ export const LoggedInBarcodeContent = () => {
     !!coords
   );
 
-  if (isLoading) return <p>바코드 불러오는 중...</p>;
+  if (isLoading) return <BeatLoader className="text-center" size={10} />;
 
   if (error && isApiError(error)) {
     if (error.statusCode !== 4103) {
@@ -84,6 +86,13 @@ export const LoggedInBarcodeContent = () => {
       {imageUrl ? (
         <div className="w-full flex">
           <CroppedImg imageUrl={imageUrl} onClick={triggerFileSelect} />
+          <button
+            onClick={triggerFileSelect}
+            className="absolute top-2 right-2 bg-white rounded-full p-2 shadow hover:bg-white"
+            aria-label="이미지 재업로드"
+          >
+            <RefreshCcw size={16} />
+          </button>
         </div>
       ) : (
         <PrimaryButton className="w-full" onClick={triggerFileSelect}>

--- a/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
+++ b/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
@@ -88,7 +88,7 @@ export const LoggedInBarcodeContent = () => {
           <CroppedImg imageUrl={imageUrl} onClick={triggerFileSelect} />
           <button
             onClick={triggerFileSelect}
-            className="absolute top-2 right-0 bg-white rounded-full hover:bg-white cursor-pointer px-3"
+            className="absolute top-2 right-0 bg-white rounded-full hover:bg-white cursor-pointer mr-3"
             aria-label="이미지 재업로드"
           >
             <ImageUp size={17} />

--- a/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
+++ b/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
@@ -88,7 +88,7 @@ export const LoggedInBarcodeContent = () => {
           <CroppedImg imageUrl={imageUrl} onClick={triggerFileSelect} />
           <button
             onClick={triggerFileSelect}
-            className="absolute top-2 right-0 bg-white rounded-full hover:bg-white cursor-pointer px-1"
+            className="absolute top-2 right-0 bg-white rounded-full hover:bg-white cursor-pointer px-3"
             aria-label="이미지 재업로드"
           >
             <ImageUp size={17} />

--- a/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
+++ b/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
@@ -88,10 +88,10 @@ export const LoggedInBarcodeContent = () => {
           <CroppedImg imageUrl={imageUrl} onClick={triggerFileSelect} />
           <button
             onClick={triggerFileSelect}
-            className="absolute top-2 right-2 bg-white rounded-full p-2 shadow hover:bg-white cursor-pointer"
+            className="absolute top-2 right-0 bg-white rounded-full hover:bg-white cursor-pointer px-1"
             aria-label="이미지 재업로드"
           >
-            <ImageUp size={16} />
+            <ImageUp size={17} />
           </button>
         </div>
       ) : (

--- a/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
+++ b/src/shared/components/bottom_navigation/barcode/contents/LoggedInBarcodeContent.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import VisitConfirmSection from '@barcode/components/VisitConfirmSection';
 import { useBarcodeImageQuery } from '@barcode/hooks/useBarcodeImageQuery';
 import { useNearbyStoreQuery } from '@barcode/hooks/useNearbyStoreQuery';
-import { RefreshCcw } from 'lucide-react';
+import { ImageUp } from 'lucide-react';
 import { BeatLoader } from 'react-spinners';
 
 import { PrimaryButton } from '@/shared/components';
@@ -74,7 +74,7 @@ export const LoggedInBarcodeContent = () => {
   }
 
   return (
-    <div className="flex flex-col w-full gap-4">
+    <div className="flex flex-col w-full gap-4 relative">
       {store && !isConfirmed && !isRejected && (
         <VisitConfirmSection
           store={store}
@@ -88,10 +88,10 @@ export const LoggedInBarcodeContent = () => {
           <CroppedImg imageUrl={imageUrl} onClick={triggerFileSelect} />
           <button
             onClick={triggerFileSelect}
-            className="absolute top-2 right-2 bg-white rounded-full p-2 shadow hover:bg-white"
+            className="absolute top-2 right-2 bg-white rounded-full p-2 shadow hover:bg-white cursor-pointer"
             aria-label="이미지 재업로드"
           >
-            <RefreshCcw size={16} />
+            <ImageUp size={16} />
           </button>
         </div>
       ) : (

--- a/src/shared/components/sidebar/LoggedInContent.tsx
+++ b/src/shared/components/sidebar/LoggedInContent.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { PATH } from '@paths';
 import { LogoutButton } from '@user/components/LogoutButton';
 import { ChevronRight } from 'lucide-react';
@@ -8,16 +6,25 @@ import { HiGift } from 'react-icons/hi';
 import { LiaBarcodeSolid } from 'react-icons/lia';
 import { useNavigate } from 'react-router-dom';
 
-import { BarcodeBottomSheet } from '@/shared/components/bottom_navigation/barcode/BarcodeBottomSheet';
 import { SheetClose } from '@/shared/components/shadcn/ui/sheet';
+import { useBarcodeStore } from '@/shared/store/barcodeStore';
 import { useUser } from '@/shared/store/userStore';
 
+// 메뉴 아이템 타입 정의
+interface MenuItem {
+  type: 'page' | 'modal';
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  title: string;
+  description: string;
+  path?: string;
+}
+
 const LoggedInContent = () => {
-  const [isBarcodeOpen, setIsBarcodeOpen] = useState(false);
   const user = useUser();
   const navigate = useNavigate();
+  const { open } = useBarcodeStore();
 
-  const menuItems = [
+  const menuItems: MenuItem[] = [
     {
       type: 'page',
       icon: FaMapMarkerAlt,
@@ -85,8 +92,8 @@ const LoggedInContent = () => {
               <button
                 onClick={() =>
                   item.type === 'modal'
-                    ? setIsBarcodeOpen(true)
-                    : item.path && item.path && navigate(item.path)
+                    ? open() // ✅ 전역으로 열기
+                    : item.path && navigate(item.path)
                 }
                 className="w-full bg-white border border-light-gray rounded-xl p-3 hover:bg-gray-hover hover:shadow-sm active:scale-[0.98] transition-all duration-150"
               >
@@ -111,12 +118,6 @@ const LoggedInContent = () => {
         <div className="border border-gray" />
         <LogoutButton />
       </div>
-
-      {/* 바코드 모달 */}
-      <BarcodeBottomSheet
-        isOpen={isBarcodeOpen}
-        onClose={() => setIsBarcodeOpen(false)}
-      />
     </div>
   );
 };

--- a/src/shared/store/barcodeStore.ts
+++ b/src/shared/store/barcodeStore.ts
@@ -2,10 +2,16 @@ import { create } from 'zustand';
 
 interface BarcodeState {
   imageUrl: string | null;
+  isOpen: boolean;
   setImageUrl: (url: string) => void;
+  open: () => void;
+  close: () => void;
 }
 
 export const useBarcodeStore = create<BarcodeState>(set => ({
   imageUrl: null,
+  isOpen: false,
   setImageUrl: url => set({ imageUrl: url }),
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
 }));


### PR DESCRIPTION
[![UHYU-355](https://badgen.net/badge/JIRA/UHYU-355/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-355) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=refactor/UHYU-355-bacode-modal)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:refactor/UHYU-355-bacode-modal) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
바코드 모달 컨텐츠 부분 넘치는 거 해결
이미지 재업로드 아이콘 추가
사이드바에서 바코드 바로가기 누르면 바코드 바텀시트 열리게 연결

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-355]: https://u-hyu.atlassian.net/browse/UHYU-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 바코드 하단 시트가 전역 상태 관리로 전환되어 여러 컴포넌트에서 일관되게 열고 닫을 수 있습니다.
  * 바코드 시트가 화면의 주요 콘텐츠 영역에 포털 방식으로 표시됩니다.
  * 바코드 이미지 로딩 시 텍스트 대신 시각적 스피너가 표시됩니다.
  * 바코드 이미지 옆에 이미지 재업로드 버튼이 추가되었습니다.
  * 게스트 바코드 화면에 카카오 로그인 버튼이 별도 컴포넌트로 교체되었습니다.

* **리팩터**
  * 바코드 관련 모달/시트 상태 관리가 각 컴포넌트의 지역 상태에서 전역 스토어로 통합되었습니다.
  * 일부 메뉴 항목 구조가 명확하게 타입화되었습니다.
  * 바코드 하단 내비게이션 및 사이드바 컴포넌트에서 상태 관리 및 렌더링 로직이 간소화되었습니다.

* **스타일**
  * 바코드 시트와 오버레이의 스타일이 개선되었습니다.
  * 바코드 이미지 업로드 버튼에 시각적 효과가 추가되었습니다.

* **기타**
  * 주요 콘텐츠 영역에 id 속성("main-content")이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->