### PR TITLE
[UHYU-360][FEAT] 마커 클릭, 바텀시트 매장 클릭시 줌 레벨 4로 고정

### DIFF
--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -68,16 +68,16 @@ export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
     const handleStoreClick = useCallback(
       (store: Store) => {
         // 로그인 상태 확인 후 인포윈도우 표시
-        checkAuthAndExecuteModal(() => {
-          // 바텀시트 명시적 닫힘 플래그 설정 후 닫기
-          if (bottomSheetRef && bottomSheetRef.current) {
-            bottomSheetRef.current.setExplicitlyClosed(true);
-            bottomSheetRef.current.close();
-          }
+        // checkAuthAndExecuteModal(() => {
+        // 바텀시트 명시적 닫힘 플래그 설정 후 닫기
+        if (bottomSheetRef && bottomSheetRef.current) {
+          bottomSheetRef.current.setExplicitlyClosed(true);
+          bottomSheetRef.current.close();
+        }
 
-          // 지도 마커 클릭과 동일한 효과 (바텀시트 닫고 인포윈도우 표시)
-          handleMapMarkerClick(store);
-        });
+        // 지도 마커 클릭과 동일한 효과 (바텀시트 닫고 인포윈도우 표시)
+        handleMapMarkerClick(store);
+        // });
       },
       [bottomSheetRef, handleMapMarkerClick, checkAuthAndExecuteModal]
     );
@@ -98,7 +98,6 @@ export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
 
     // 필터 버튼 클릭 핸들러 - 바텀시트 높이 유지
     const handleFilterClick = (e?: React.MouseEvent) => {
-
       if (e) {
         e.stopPropagation();
       }
@@ -148,7 +147,6 @@ export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
 
     // 현재 바텀시트 단계에 따른 콘텐츠 렌더링
     const getCurrentStepContent = () => {
-
       switch (currentBottomSheetStep) {
         case 'list':
           return (

--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -68,16 +68,16 @@ export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
     const handleStoreClick = useCallback(
       (store: Store) => {
         // 로그인 상태 확인 후 인포윈도우 표시
-        // checkAuthAndExecuteModal(() => {
-        // 바텀시트 명시적 닫힘 플래그 설정 후 닫기
-        if (bottomSheetRef && bottomSheetRef.current) {
-          bottomSheetRef.current.setExplicitlyClosed(true);
-          bottomSheetRef.current.close();
-        }
+        checkAuthAndExecuteModal(() => {
+          // 바텀시트 명시적 닫힘 플래그 설정 후 닫기
+          if (bottomSheetRef && bottomSheetRef.current) {
+            bottomSheetRef.current.setExplicitlyClosed(true);
+            bottomSheetRef.current.close();
+          }
 
-        // 지도 마커 클릭과 동일한 효과 (바텀시트 닫고 인포윈도우 표시)
-        handleMapMarkerClick(store);
-        // });
+          // 지도 마커 클릭과 동일한 효과 (바텀시트 닫고 인포윈도우 표시)
+          handleMapMarkerClick(store);
+        });
       },
       [bottomSheetRef, handleMapMarkerClick, checkAuthAndExecuteModal]
     );

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -260,51 +260,51 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   const handleMarkerClick = useCallback(
     (store: Store) => {
       // 로그인 상태 확인 후 인포윈도우 표시
-      // checkAuthAndExecuteModal(() => {
-      setInternalSelectedStoreId(store.storeId);
-      setInfoWindowStore(store);
-
-      // 추천 매장인지 확인
-      const isRecommended = recommendedStores.some(
-        s => s.storeId === store.storeId
-      );
-      if (isRecommended) {
-        setRecommendedInfoWindowStore(store);
-      } else {
+      checkAuthAndExecuteModal(() => {
+        setInternalSelectedStoreId(store.storeId);
         setInfoWindowStore(store);
-      }
 
-      trackMarkerClick(store.storeId);
+        // 추천 매장인지 확인
+        const isRecommended = recommendedStores.some(
+          s => s.storeId === store.storeId
+        );
+        if (isRecommended) {
+          setRecommendedInfoWindowStore(store);
+        } else {
+          setInfoWindowStore(store);
+        }
 
-      // 인포 윈도우가 화면 중앙에 오도록 오프셋 적용
-      const offset = 0.0017;
-      const targetLat = store.latitude + offset;
-      const targetLng = store.longitude;
-      const targetCenter = { lat: targetLat, lng: targetLng };
+        trackMarkerClick(store.storeId);
 
-      // KakaoMap의 isPanto를 사용한 부드러운 이동
-      setIsPanto(true);
-      setMapCenter(targetCenter);
+        // 인포 윈도우가 화면 중앙에 오도록 오프셋 적용
+        const offset = 0.0017;
+        const targetLat = store.latitude + offset;
+        const targetLng = store.longitude;
+        const targetCenter = { lat: targetLat, lng: targetLng };
 
-      // 지도 레벨을 4로 변경
-      if (mapRef.current) {
-        mapRef.current.setLevel(4);
-      }
+        // KakaoMap의 isPanto를 사용한 부드러운 이동
+        setIsPanto(true);
+        setMapCenter(targetCenter);
 
-      // 기존 timeout이 있다면 정리
-      if (pantoTimeoutRef.current) {
-        clearTimeout(pantoTimeoutRef.current);
-      }
+        // 지도 레벨을 4로 변경
+        if (mapRef.current) {
+          mapRef.current.setLevel(4);
+        }
 
-      // 애니메이션 완료 후 isPanto 리셋
-      pantoTimeoutRef.current = setTimeout(() => {
-        setIsPanto(false);
-        pantoTimeoutRef.current = null;
-      }, 500); // 애니메이션 시간을 500ms로 증가
+        // 기존 timeout이 있다면 정리
+        if (pantoTimeoutRef.current) {
+          clearTimeout(pantoTimeoutRef.current);
+        }
 
-      // 외부에서 전달받은 onStoreClick 콜백도 호출
-      onStoreClick?.(store);
-      // });
+        // 애니메이션 완료 후 isPanto 리셋
+        pantoTimeoutRef.current = setTimeout(() => {
+          setIsPanto(false);
+          pantoTimeoutRef.current = null;
+        }, 500); // 애니메이션 시간을 500ms로 증가
+
+        // 외부에서 전달받은 onStoreClick 콜백도 호출
+        onStoreClick?.(store);
+      });
     },
     [onStoreClick, recommendedStores]
   );

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -181,6 +181,11 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         setIsPanto(true);
         setMapCenter(targetCenter);
 
+        // 지도 레벨을 4로 변경 (바텀시트에서 매장 선택시)
+        if (mapRef.current) {
+          mapRef.current.setLevel(4);
+        }
+
         if (pantoTimeoutRef.current) {
           clearTimeout(pantoTimeoutRef.current);
         }
@@ -224,6 +229,11 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         setIsPanto(true);
         setMapCenter(targetCenter);
 
+        // 지도 레벨을 4로 변경
+        if (mapRef.current) {
+          mapRef.current.setLevel(4);
+        }
+
         // 기존 timeout이 있다면 정리
         if (pantoTimeoutRef.current) {
           clearTimeout(pantoTimeoutRef.current);
@@ -250,48 +260,53 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   const handleMarkerClick = useCallback(
     (store: Store) => {
       // 로그인 상태 확인 후 인포윈도우 표시
-      checkAuthAndExecuteModal(() => {
-        setInternalSelectedStoreId(store.storeId);
+      // checkAuthAndExecuteModal(() => {
+      setInternalSelectedStoreId(store.storeId);
+      setInfoWindowStore(store);
+
+      // 추천 매장인지 확인
+      const isRecommended = recommendedStores.some(
+        s => s.storeId === store.storeId
+      );
+      if (isRecommended) {
+        setRecommendedInfoWindowStore(store);
+      } else {
         setInfoWindowStore(store);
+      }
 
-        // 추천 매장인지 확인
-        const isRecommended = recommendedStores.some(
-          s => s.storeId === store.storeId
-        );
-        if (isRecommended) {
-          setRecommendedInfoWindowStore(store);
-        } else {
-          setInfoWindowStore(store);
-        }
+      trackMarkerClick(store.storeId);
 
-        trackMarkerClick(store.storeId);
+      // 인포 윈도우가 화면 중앙에 오도록 오프셋 적용
+      const offset = 0.0017;
+      const targetLat = store.latitude + offset;
+      const targetLng = store.longitude;
+      const targetCenter = { lat: targetLat, lng: targetLng };
 
-        // 인포 윈도우가 화면 중앙에 오도록 오프셋 적용
-        const offset = 0.0017;
-        const targetLat = store.latitude + offset;
-        const targetLng = store.longitude;
-        const targetCenter = { lat: targetLat, lng: targetLng };
+      // KakaoMap의 isPanto를 사용한 부드러운 이동
+      setIsPanto(true);
+      setMapCenter(targetCenter);
 
-        // KakaoMap의 isPanto를 사용한 부드러운 이동
-        setIsPanto(true);
-        setMapCenter(targetCenter);
+      // 지도 레벨을 4로 변경
+      if (mapRef.current) {
+        mapRef.current.setLevel(4);
+      }
 
-        // 기존 timeout이 있다면 정리
-        if (pantoTimeoutRef.current) {
-          clearTimeout(pantoTimeoutRef.current);
-        }
+      // 기존 timeout이 있다면 정리
+      if (pantoTimeoutRef.current) {
+        clearTimeout(pantoTimeoutRef.current);
+      }
 
-        // 애니메이션 완료 후 isPanto 리셋
-        pantoTimeoutRef.current = setTimeout(() => {
-          setIsPanto(false);
-          pantoTimeoutRef.current = null;
-        }, 500); // 애니메이션 시간을 500ms로 증가
+      // 애니메이션 완료 후 isPanto 리셋
+      pantoTimeoutRef.current = setTimeout(() => {
+        setIsPanto(false);
+        pantoTimeoutRef.current = null;
+      }, 500); // 애니메이션 시간을 500ms로 증가
 
-        // 외부에서 전달받은 onStoreClick 콜백도 호출
-        onStoreClick?.(store);
-      });
+      // 외부에서 전달받은 onStoreClick 콜백도 호출
+      onStoreClick?.(store);
+      // });
     },
-    [onStoreClick, checkAuthAndExecuteModal, recommendedStores]
+    [onStoreClick, recommendedStores]
   );
 
   // 추천 매장인지 확인하는 함수

--- a/src/features/kakao-map/hooks/useMapInteraction.ts
+++ b/src/features/kakao-map/hooks/useMapInteraction.ts
@@ -4,7 +4,7 @@ import type { Store } from '../types/store';
 import { useMapData } from './useMapData';
 import { useMapUI } from './useMapUI';
 
-export const useMapInteraction = () => {
+export const useMapInteraction = (mapRef?: React.RefObject<kakao.maps.Map>) => {
   const { selectStore, setMapCenter } = useMapData();
   const { setSelectedMarker, selectedMarkerId } = useMapUI();
 
@@ -14,8 +14,13 @@ export const useMapInteraction = () => {
       setSelectedMarker(store.storeId);
       selectStore(store);
       setMapCenter({ lat: store.latitude, lng: store.longitude });
+      
+      // 지도 레벨을 4로 변경
+      if (mapRef?.current) {
+        mapRef.current.setLevel(4);
+      }
     },
-    [selectStore, setMapCenter, setSelectedMarker]
+    [selectStore, setMapCenter, setSelectedMarker, mapRef]
   );
 
   // 지도 중심점 변경 처리


### PR DESCRIPTION
[![UHYU-360](https://badgen.net/badge/JIRA/UHYU-360/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-360) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-360-offset)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-360-offset) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

1. 카카오 맵 인스턴스 ref를 이용하여 직접 줌 레벨 변경 방식 도입
2. 인포윈도우 열림 동작 ( 바텀시트 매장 클릭, 마커 클릭) 시 항상 지도 줌 레벨 4 로 변경하여 오프셋 최적화

# 현재 UI 캡처


|:--:|
|
![화면 기록 2025-08-03 14 43 48](https://github.com/user-attachments/assets/fb542c91-a0ed-4622-9a46-b103361bf696)
|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-360]: https://u-hyu.atlassian.net/browse/UHYU-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 선택 또는 마커 클릭 시 지도의 중심이 변경될 때마다 지도 확대/축소 레벨이 자동으로 4로 설정됩니다.

* **스타일**
  * 불필요한 공백이 제거되어 코드가 더욱 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->