### PR TITLE
[REFACTOR][UHYU-349] 마이페이지 관심 브랜드 api 연결 및 활동내역 UI

### DIFF
--- a/src/features/mypage/api/mockData.ts
+++ b/src/features/mypage/api/mockData.ts
@@ -11,9 +11,9 @@ export const mockUserInfoData: UserInfoData = {
   age: 27,
   gender: 'MALE',
   grade: 'VVIP',
-  role: 'ADMIN',
-  // role: 'USER',    // 마이페이지 확인하려면 유저 타입 변경
-  interestedBrandList: [1, 2, 3],
+  // role: 'ADMIN',
+  role: 'USER',    // 마이페이지 확인하려면 유저 타입 변경
+  interestedBrandList: [2, 15, 25],
   updatedAt: '2025-07-28T02:25:39.470165',
 };
 

--- a/src/features/mypage/api/mypageApi.ts
+++ b/src/features/mypage/api/mypageApi.ts
@@ -13,29 +13,60 @@ import { client } from '@/shared/client';
 // --- 마이페이지(개인정보/브랜드 등) 기존 API ---
 export const fetchUserInfo = async (): Promise<UserInfoData> => {
   const res = await client.get<ApiResponse<UserInfoData>>(MYPAGE_ENDPOINTS.USER_INFO);
-  if (!res.data.data) throw new Error('Invalid API response: missing data');
+  
+  // statusCode가 0이 아니거나 data가 없으면 에러
+  if (res.data.statusCode !== 0 || !res.data.data) {
+    throw new Error(res.data.message || 'Invalid API response: missing data');
+  }
+  
   return res.data.data;
 };
 
 export const updateUserInfo = async (update: UpdateUserRequest): Promise<UpdateUserResponseData> => {
   const res = await client.patch<ApiResponse<UpdateUserResponseData>>(MYPAGE_ENDPOINTS.UPDATE_USER, update);
-  if (!res.data.data) throw new Error('Invalid API response: missing data');
+  
+  // statusCode가 0이 아니거나 data가 없으면 에러
+  if (res.data.statusCode !== 0 || !res.data.data) {
+    throw new Error(res.data.message || 'Invalid API response: missing data');
+  }
+  
   return res.data.data;
 };
 
-// --- 액티비티(활동내역/즐겨찾기) API ---
 export const fetchActivityStatistics = async (): Promise<ActivityStatistics> => {
   const res = await client.get<ApiResponse<ActivityStatistics>>(MYPAGE_ENDPOINTS.STATISTICS);
-  if (!res.data.data) throw new Error('Invalid API response: missing data');
+  
+  // statusCode가 0이 아니거나 data가 없으면 에러
+  if (res.data.statusCode !== 0 || !res.data.data) {
+    throw new Error(res.data.message || 'Invalid API response: missing data');
+  }
+  
+  return res.data.data;
+};
+
+export const fetchAllBookmarks = async (): Promise<Bookmark[]> => {
+  const res = await client.get<ApiResponse<Bookmark[]>>(MYPAGE_ENDPOINTS.BOOKMARK_LIST);
+  
+  // statusCode가 0이 아니거나 data가 없으면 에러
+  if (res.data.statusCode !== 0 || !res.data.data) {
+    throw new Error(res.data.message || 'Invalid API response: missing data');
+  }
+  
   return res.data.data;
 };
 
 export const fetchBookmarkList = async (page = 1, size = 5): Promise<Bookmark[]> => {
-  const res = await client.get<ApiResponse<Bookmark[]>>(
-    `${MYPAGE_ENDPOINTS.BOOKMARK_LIST}?page=${page}&size=${size}`
-  );
-  if (!res.data.data) throw new Error('Invalid API response: missing data');
-  return res.data.data;
+  // 전체 데이터를 한 번만 가져와서 캐시
+  const allBookmarks = await fetchAllBookmarks();
+  
+  // 프론트엔드에서 페이지네이션 적용
+  const start = (page - 1) * size;
+  const end = start + size;
+  const pagedBookmarks = allBookmarks.slice(start, end);
+  
+  console.log('🔧 프론트엔드 무한스크롤 페이지네이션:', { page, size, start, end, total: allBookmarks.length, paged: pagedBookmarks.length });
+  
+  return pagedBookmarks;
 };
 
 export const deleteBookmark = async (bookmarkId: number): Promise<{ statusCode: number; message: string }> => {

--- a/src/features/mypage/components/ActivityBenefit.tsx
+++ b/src/features/mypage/components/ActivityBenefit.tsx
@@ -2,15 +2,47 @@ import { useActivityStatisticsQuery } from '@mypage/hooks/useActivityQuery';
 
 const ActivityBenefit = () => {
   const { data, isLoading, error } = useActivityStatisticsQuery();
+  
   if (isLoading) return <div>로딩중...</div>;
-  if (error || !data) return <div>에러 발생</div>;
+  
+  if (error || !data || data.discountMoney === null || data.discountMoney === 0) {
+    return (
+      <div className="border border-gray-200 rounded-[1rem] p-[1.25rem]">
+        <div className="rounded-[1rem] bg-white px-[1.25rem] py-[1.5rem] text-center">
+          <p className="text-[0.75rem] text-gray mb-[0.5rem]">이번 달 받은 혜택</p>
+          
+          {/* 빈 상태 UI */}
+          <div className="flex flex-col items-center justify-center py-[1rem]">
+            {/* 돼지저금통 아이콘 */}
+            <div className="relative w-[3rem] h-[3rem] mb-[0.75rem]">
+              <div className="absolute inset-0 bg-gradient-to-br from-yellow-400 to-orange-500 rounded-full flex items-center justify-center shadow-sm">
+                <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                </svg>
+              </div>
+              <div className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full flex items-center justify-center">
+                <span className="text-white text-xs font-bold">₩</span>
+              </div>
+            </div>
+            
+            <p className="font-medium text-[0.875rem] text-gray-700 mb-[0.25rem]">아직 혜택이 없어요</p>
+            <p className="text-[0.75rem] text-gray-500">
+              지도에서 매장을 찾아서 다양한 혜택을 받아보세요!
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 정상 데이터가 있을 때는 원래 UI 그대로
   return (
     <div className="border border-gray-200 rounded-[1rem] p-[1.25rem]">
       <div className="rounded-[1rem] bg-white px-[1.25rem] py-[1.5rem] text-center">
         <p className="text-[0.75rem] text-gray mb-[0.5rem]">이번 달 받은 혜택</p>
         <img src="/images/benefit/image.png" alt="benefit" className="mx-auto h-[4.5rem]" />
         <p className="font-bold text-[1.125rem] text-black mt-[0.5rem]">
-          {data.discountMoney !== null ? `${data.discountMoney.toLocaleString()}원` : '-'}
+          {data.discountMoney.toLocaleString()}원
         </p>
       </div>
     </div>

--- a/src/features/mypage/components/ActivityBrands.tsx
+++ b/src/features/mypage/components/ActivityBrands.tsx
@@ -2,8 +2,40 @@ import { useActivityStatisticsQuery } from '@mypage/hooks/useActivityQuery';
 
 const ActivityBrands = () => {
   const { data, isLoading, error } = useActivityStatisticsQuery();
+  
   if (isLoading) return <div>로딩중...</div>;
-  if (error || !data) return <div>에러 발생</div>;
+  
+  if (error || !data || !data.bestBrandList || data.bestBrandList.length === 0) {
+    return (
+      <div className="border border-gray-200 rounded-[1rem] p-[1.25rem]">
+        <div className="rounded-[1rem] bg-white px-[1.25rem] py-[1.5rem]">
+          <p className="text-[0.75rem] text-gray mb-[0.5rem]">가장 많이 방문한 브랜드</p>
+          
+          {/* 빈 상태 UI */}
+          <div className="flex flex-col items-center justify-center py-[1rem]">
+            {/* 방문 아이콘 */}
+            <div className="relative w-[3rem] h-[3rem] mb-[0.75rem]">
+              <div className="absolute inset-0 bg-gradient-to-br from-purple-400 to-pink-500 rounded-full flex items-center justify-center shadow-sm">
+                <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+                </svg>
+              </div>
+              <div className="absolute -top-1 -right-1 w-4 h-4 bg-orange-500 rounded-full flex items-center justify-center">
+                <span className="text-white text-xs font-bold">🏆</span>
+              </div>
+            </div>
+            
+            <p className="font-medium text-[0.875rem] text-gray-700 mb-[0.25rem]">아직 방문 기록이 없어요</p>
+            <p className="text-[0.75rem] text-gray-500">
+              지도에서 매장을 찾아서 방문 기록을 쌓아보세요!
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 정상 데이터가 있을 때는 원래 UI 그대로
   return (
     <div className="border border-gray-200 rounded-[1rem] p-[1.25rem]">
       <p className="text-[0.75rem] text-gray mb-[0.5rem]">가장 많이 방문한 브랜드</p>

--- a/src/features/mypage/components/ActivityFavorite.tsx
+++ b/src/features/mypage/components/ActivityFavorite.tsx
@@ -89,7 +89,7 @@ const ActivityFavorite = ({ enabled }: Props) => {
           </BrandWithFavoriteCard>
         </div>
       ))}
-      {bookmarks.length === 0 && (
+      {!isLoading && bookmarks.length === 0 && (
         <div className="flex flex-col items-center justify-center py-12 px-4">
           {/* 빈 상태 아이콘 */}
           <div className="relative mb-6">

--- a/src/features/mypage/components/ActivityFavorite.tsx
+++ b/src/features/mypage/components/ActivityFavorite.tsx
@@ -18,7 +18,6 @@ const ActivityFavorite = ({ enabled }: Props) => {
     hasNextPage,
     isFetchingNextPage,
     isLoading,
-    error,
     refetch,
   } = useBookmarkListInfiniteQuery(enabled);
   const loaderRef = useRef<HTMLDivElement | null>(null);
@@ -45,8 +44,7 @@ const ActivityFavorite = ({ enabled }: Props) => {
   if (!enabled) return null;
 
   if (isLoading) return <div>로딩중...</div>;
-  if (error) return <div>에러 발생</div>;
-
+ 
   const bookmarks = (data?.pages.flat() as Bookmark[]) || [];
 
   const handleFavoriteClick = async (bookmarkId: number) => {
@@ -91,7 +89,7 @@ const ActivityFavorite = ({ enabled }: Props) => {
           </BrandWithFavoriteCard>
         </div>
       ))}
-      {bookmarks.length === 0 && !isLoading && (
+      {bookmarks.length === 0 && (
         <div className="flex flex-col items-center justify-center py-12 px-4">
           {/* 빈 상태 아이콘 */}
           <div className="relative mb-6">

--- a/src/shared/components/AppInitializer.tsx
+++ b/src/shared/components/AppInitializer.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { PATH } from '@/routes/path';
-import { userStore } from '@/shared/store/userStore';
 
 import {
   initKeyboardHandler,
@@ -21,11 +20,7 @@ const AppInitializer = () => {
   const isAdminPage = location.pathname === PATH.ADMIN;
 
   // 관리자 페이지가 아닐 때만 사용자 정보 요청
-  useEffect(() => {
-    if (!isAdminPage) {
-      userStore.getState().initAuthState();
-    }
-  }, [isAdminPage]);
+  // const { data, isSuccess, isError } = useUserInfo(!isAdminPage);
 
   // 개발 환경에서 로깅
   if (import.meta.env.DEV) {

--- a/src/shared/components/AppInitializer.tsx
+++ b/src/shared/components/AppInitializer.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { PATH } from '@/routes/path';
+import { userStore } from '@/shared/store/userStore';
 
 import {
   initKeyboardHandler,
@@ -20,7 +21,11 @@ const AppInitializer = () => {
   const isAdminPage = location.pathname === PATH.ADMIN;
 
   // 관리자 페이지가 아닐 때만 사용자 정보 요청
-  // const { data, isSuccess, isError } = useUserInfo(!isAdminPage);
+  useEffect(() => {
+    if (!isAdminPage) {
+      userStore.getState().initAuthState();
+    }
+  }, [isAdminPage]);
 
   // 개발 환경에서 로깅
   if (import.meta.env.DEV) {


### PR DESCRIPTION
[![UHYU-349](https://badgen.net/badge/JIRA/UHYU-349/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-349) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=refactor/UHYU-349-mypage-brand-api)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:refactor/UHYU-349-mypage-brand-api) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)

마이페이지 관심 브랜드 api 연결
활동 내역에 해당 데이터가 없는 경우 각각 디자인한 UI 적용

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-349]: https://u-hyu.atlassian.net/browse/UHYU-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 마이페이지의 활동 혜택, 활동 브랜드, 즐겨찾기, 브랜드 선택 컴포넌트에서 오류 및 빈 데이터 처리 UI가 개선되어, 보다 명확하고 친절한 안내 메시지가 제공됩니다.
  * 즐겨찾기 목록 조회 시 서버에서 전체 데이터를 받아와 클라이언트에서 페이지네이션하도록 변경되었습니다.

* **기능 개선**
  * 브랜드 선택 시, 관심 브랜드 목록이 API 데이터와 동기화되어 보다 정확한 선택이 가능합니다.

* **기타**
  * 일부 목업 데이터가 수정되어 사용자 역할과 관심 브랜드 정보가 업데이트되었습니다.
  * 내부 코드 스타일 및 불필요한 코드 공백이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->