### PR TITLE
[FIX][UHYU-362] 마이페이지 즐겨찾기 전부 제거 시 발생하는 에러 해결

### DIFF
--- a/src/features/mypage/api/mockData.ts
+++ b/src/features/mypage/api/mockData.ts
@@ -11,8 +11,8 @@ export const mockUserInfoData: UserInfoData = {
   age: 27,
   gender: 'MALE',
   grade: 'VVIP',
-  // role: 'ADMIN',
-  role: 'USER',    // 마이페이지 확인하려면 유저 타입 변경
+  role: 'ADMIN',
+  // role: 'USER',    // 마이페이지 확인하려면 유저 타입 변경
   interestedBrandList: [2, 15, 25],
   updatedAt: '2025-07-28T02:25:39.470165',
 };

--- a/src/features/mypage/api/mypageApi.ts
+++ b/src/features/mypage/api/mypageApi.ts
@@ -64,8 +64,6 @@ export const fetchBookmarkList = async (page = 1, size = 5): Promise<Bookmark[]>
   const end = start + size;
   const pagedBookmarks = allBookmarks.slice(start, end);
   
-  console.log('🔧 프론트엔드 무한스크롤 페이지네이션:', { page, size, start, end, total: allBookmarks.length, paged: pagedBookmarks.length });
-  
   return pagedBookmarks;
 };
 

--- a/src/features/mypage/components/ActivityFavorite.tsx
+++ b/src/features/mypage/components/ActivityFavorite.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useBookmarkListInfiniteQuery } from '@mypage/hooks/useActivityQuery';
 import { BrandWithFavoriteCard } from '@/shared/components/cards/BrandWithFavoriteCard';
 import { deleteBookmark } from '@mypage/api/mypageApi';
@@ -12,13 +13,13 @@ interface Props {
 
 const ActivityFavorite = ({ enabled }: Props) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const {
     data,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
     isLoading,
-    refetch,
   } = useBookmarkListInfiniteQuery(enabled);
   const loaderRef = useRef<HTMLDivElement | null>(null);
   const [removingIds, setRemovingIds] = useState<number[]>([]);
@@ -51,7 +52,8 @@ const ActivityFavorite = ({ enabled }: Props) => {
     setRemovingIds((prev) => [...prev, bookmarkId]);
     try {
       await deleteBookmark(bookmarkId);
-      await refetch();
+      // 캐시를 무효화하여 데이터를 새로 가져오기
+      await queryClient.invalidateQueries({ queryKey: ['bookmarkList'] });
     } catch (error) {
       console.error('즐겨찾기 삭제 실패:', error);
       // 에러 발생 시 removingIds에서 제거

--- a/src/shared/components/AppInitializer.tsx
+++ b/src/shared/components/AppInitializer.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { PATH } from '@/routes/path';
+import { userStore } from '@/shared/store/userStore';
 
 import {
   initKeyboardHandler,
@@ -18,9 +19,6 @@ const AppInitializer = () => {
 
   // 관리자 페이지에서는 사용자 정보 요청을 하지 않음
   const isAdminPage = location.pathname === PATH.ADMIN;
-
-  // 관리자 페이지가 아닐 때만 사용자 정보 요청
-  // const { data, isSuccess, isError } = useUserInfo(!isAdminPage);
 
   // 개발 환경에서 로깅
   if (import.meta.env.DEV) {
@@ -49,6 +47,13 @@ const AppInitializer = () => {
       cleanupKeyboardHandler();
     };
   }, []);
+
+  // 관리자 페이지가 아닐 때만 사용자 인증 상태 초기화
+  useEffect(() => {
+    if (!isAdminPage) {
+      userStore.getState().initAuthState();
+    }
+  }, [isAdminPage]);
 
   return null;
 };

--- a/src/shared/components/AppInitializer.tsx
+++ b/src/shared/components/AppInitializer.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { PATH } from '@/routes/path';
-import { userStore } from '@/shared/store/userStore';
 
 import {
   initKeyboardHandler,
@@ -19,6 +18,9 @@ const AppInitializer = () => {
 
   // 관리자 페이지에서는 사용자 정보 요청을 하지 않음
   const isAdminPage = location.pathname === PATH.ADMIN;
+
+  // 관리자 페이지가 아닐 때만 사용자 정보 요청
+  // const { data, isSuccess, isError } = useUserInfo(!isAdminPage);
 
   // 개발 환경에서 로깅
   if (import.meta.env.DEV) {
@@ -47,13 +49,6 @@ const AppInitializer = () => {
       cleanupKeyboardHandler();
     };
   }, []);
-
-  // 관리자 페이지가 아닐 때만 사용자 인증 상태 초기화
-  useEffect(() => {
-    if (!isAdminPage) {
-      userStore.getState().initAuthState();
-    }
-  }, [isAdminPage]);
 
   return null;
 };


### PR DESCRIPTION
[![UHYU-362](https://badgen.net/badge/JIRA/UHYU-362/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-362) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-362-adminpage-brand-error)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-362-adminpage-brand-error) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)

마이페이지 즐겨찾기 전부 제거 시 발생하는 에러 해결

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-362]: https://u-hyu.atlassian.net/browse/UHYU-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 즐겨찾기 삭제 후 목록이 자동으로 새로고침되도록 캐시 무효화 방식을 개선했습니다.
  * 불필요한 콘솔 로그가 제거되었습니다.

* **기타**
  * 목업 사용자 정보의 역할이 'ADMIN'으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->