### PR TITLE
[FEAT][UHYU-375] 스토어 타입 brandId 값 받아오게 추가

### DIFF
--- a/src/features/kakao-map/types/store.ts
+++ b/src/features/kakao-map/types/store.ts
@@ -6,6 +6,7 @@ export interface Store {
   benefit: string; // 매장 혜택 정보
   logoImage: string; // 브랜드 로고 이미지 URL
   brandName: string; // 브랜드 이름 (백엔드에서 정규화됨)
+  brandId?: number;
   latitude: number; // 위도
   longitude: number; // 경도
 }

--- a/src/features/recommendation/api/recommendedStoresApi.ts
+++ b/src/features/recommendation/api/recommendedStoresApi.ts
@@ -34,10 +34,10 @@ export const getRecommendedRanking = async (): Promise<
 };
 
 export const postRecommendExclude = async (
-  storeId: number
+  brandId: number
 ): Promise<ApiResponse> => {
   const res = await client.post<ApiResponse>(RECOMMEND_ENDPOINT.EXCLUDE, {
-    storeId,
+    brandId,
   });
 
   return res.data;

--- a/src/features/recommendation/components/RecommendedCard.tsx
+++ b/src/features/recommendation/components/RecommendedCard.tsx
@@ -41,9 +41,9 @@ const RecommendedStoreCard = ({
 
   const handleDislikeClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!isExcluding) {
+    if (!isExcluding && store.brandId !== undefined) {
       setIsExcluding(true);
-      excludeStore(store.storeId, {
+      excludeStore(store.brandId, {
         onSettled: () => setIsExcluding(false),
       });
     }

--- a/src/features/recommendation/hooks/useRecommendMutation.ts
+++ b/src/features/recommendation/hooks/useRecommendMutation.ts
@@ -10,8 +10,8 @@ export const useRecommendExcludeMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (storeId: number) => postRecommendExclude(storeId),
-    onSuccess: (res, storeId) => {
+    mutationFn: (brandId: number) => postRecommendExclude(brandId),
+    onSuccess: (res, brandId) => {
       toast.success(res.message || '추천 목록에서 제외했습니다.');
 
       // ✅ 동일 브랜드 매장을 추천 목록에서 제거
@@ -19,7 +19,7 @@ export const useRecommendExcludeMutation = () => {
         ['recommendStoresByLocation'],
         oldData => {
           if (!oldData) return [];
-          return oldData.filter(item => item.storeId !== storeId);
+          return oldData.filter(item => item.brandId !== brandId);
         }
       );
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2799,12 +2799,12 @@ fraction.js@^4.3.7:
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
 framer-motion@^12.23.1:
-  version "12.23.3"
-  resolved "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.3.tgz"
-  integrity sha512-llmLkf44zuIZOPSrE4bl4J0UTg6bav+rlKEfMRKgvDMXqBrUtMg6cspoQeRVK3nqRLxTmAJhfGXk39UDdZD7Kw==
+  version "12.23.1"
+  resolved "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.1.tgz"
+  integrity sha512-7P1t2DnKEUXvPxVZJu9Hd4gfdoUF6z9U3w3/MUXCVFNHiFV+iSoboqeK4/ZCCpa49/ZiVEWfaaYCPscqPPsOVQ==
   dependencies:
-    motion-dom "^12.23.2"
-    motion-utils "^12.23.2"
+    motion-dom "^12.23.1"
+    motion-utils "^12.23.1"
     tslib "^2.4.0"
 
 fsevents@~2.3.2, fsevents@2.3.2:
@@ -3440,17 +3440,17 @@ mkdirp@^3.0.1:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz"
   integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
-motion-dom@^12.23.2:
-  version "12.23.2"
-  resolved "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.2.tgz"
-  integrity sha512-73j6xDHX/NvVh5L5oS1ouAVnshsvmApOq4F3VZo5MkYSD/YVsVLal4Qp9wvVgJM9uU2bLZyc0Sn8B9c/MMKk4g==
+motion-dom@^12.23.1:
+  version "12.23.1"
+  resolved "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.1.tgz"
+  integrity sha512-kcMDS8yhUZgO7iu3FB0UYZpHUymZlj4aoEqH0Vf0k3JtZA0xfYIrmbDlKn6X7+INXV3hDAIBUf4aT5jEUHvvWQ==
   dependencies:
-    motion-utils "^12.23.2"
+    motion-utils "^12.23.1"
 
-motion-utils@^12.23.2:
-  version "12.23.2"
-  resolved "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.2.tgz"
-  integrity sha512-cIEXlBlXAOUyiAtR0S+QPQUM9L3Diz23Bo+zM420NvSd/oPQJwg6U+rT+WRTpp0rizMsBGQOsAwhWIfglUcZfA==
+motion-utils@^12.23.1:
+  version "12.23.1"
+  resolved "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.1.tgz"
+  integrity sha512-coqLmHUTBA1KyBNEO64sTCWlduDV5Q6Yv0szjxnHVzZmcFYpVowyP6S38iOUlhocannaCCHlZ06lyLWQe/jheQ==
 
 mrmime@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
[![UHYU-375](https://badgen.net/badge/JIRA/UHYU-375/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-375) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-375-Store-type-brandId-add)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-375-Store-type-brandId-add) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
지도에서 매장정보를 가져올 때 brandId까지 넘겨받는걸로 바꾸고
싫어요 전송할때 brandId를 넘기게 수정.

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-375]: https://u-hyu.atlassian.net/browse/UHYU-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 정보에 브랜드 식별자(brandId) 속성이 추가되었습니다.

* **버그 수정**
  * 추천 매장 제외 기능에서 브랜드 단위로 제외가 적용되도록 개선되었습니다. 이제 브랜드 식별자가 정의된 경우에만 제외가 가능합니다.

* **기타**
  * 추천 제외 관련 용어가 storeId에서 brandId로 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->