### PR TITLE
[FEAT][UHYU-379] 추천카드에서 싫어요 버튼 클릭시 모달창 뜨게 수정

### DIFF
--- a/src/features/recommendation/components/ConfirmExcludeModalContent.tsx
+++ b/src/features/recommendation/components/ConfirmExcludeModalContent.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import { useRecommendExcludeMutation } from '@recommendation/hooks/useRecommendMutation';
+
+import { useModalStore } from '@/shared/store';
+
+interface ConfirmExcludeModalContentProps {
+  brandId: number;
+  brandName: string;
+}
+
+const ConfirmExcludeModalContent = ({
+  brandId,
+  brandName,
+}: ConfirmExcludeModalContentProps) => {
+  const { closeModal } = useModalStore();
+  const { mutate: excludeStore } = useRecommendExcludeMutation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = () => {
+    setIsLoading(true);
+    excludeStore(brandId, {
+      onSettled: () => {
+        setIsLoading(false);
+        closeModal();
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-black">
+        정말 <strong className="text-primary text-lg">{brandName}</strong>{' '}
+        브랜드를 추천에서 제외하시겠습니까?
+      </p>
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={() => closeModal()}
+          className="px-4 py-2 bg-light-gray rounded hover:bg-gray-hover"
+        >
+          취소
+        </button>
+        <button
+          onClick={handleConfirm}
+          className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+          disabled={isLoading}
+        >
+          {isLoading ? '처리 중...' : '확인'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmExcludeModalContent;

--- a/src/features/recommendation/components/RecommendedCard.tsx
+++ b/src/features/recommendation/components/RecommendedCard.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react';
-
 import { useMapUIContext } from '@kakao-map/context/MapUIContext';
 import { useMapStore } from '@kakao-map/store/MapStore';
 import type { Store } from '@kakao-map/types/store';
-import { useRecommendExcludeMutation } from '@recommendation/hooks/useRecommendMutation';
+import ConfirmExcludeModalContent from '@recommendation/components/ConfirmExcludeModalContent';
 import { ThumbsDown } from 'lucide-react';
 
 import { BrandCard } from '@/shared/components';
+import { useModalStore } from '@/shared/store';
 
 export interface RecommendedStoreCardProps {
   store: Store;
@@ -20,8 +19,7 @@ const RecommendedStoreCard = ({
   const selectStore = useMapStore(state => state.selectStore);
   const setMapCenter = useMapStore(state => state.setMapCenter);
   const { bottomSheetRef } = useMapUIContext();
-  const [isExcluding, setIsExcluding] = useState(false);
-  const { mutate: excludeStore } = useRecommendExcludeMutation();
+  const { openModal } = useModalStore();
 
   const handleCardClick = () => {
     if (!store.addressDetail) return; // 온라인 매장은 클릭 무시
@@ -41,12 +39,17 @@ const RecommendedStoreCard = ({
 
   const handleDislikeClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!isExcluding && store.brandId !== undefined) {
-      setIsExcluding(true);
-      excludeStore(store.brandId, {
-        onSettled: () => setIsExcluding(false),
-      });
-    }
+    if (!store.brandId) return;
+
+    openModal('base', {
+      title: '앞으로 이 브랜드는 추천에서 제외 됩니다.',
+      children: (
+        <ConfirmExcludeModalContent
+          brandId={store.brandId}
+          brandName={store.brandName}
+        />
+      ),
+    });
   };
 
   return (
@@ -86,7 +89,6 @@ const RecommendedStoreCard = ({
         <button
           onClick={handleDislikeClick}
           className="absolute top-2 right-2 p-1 mr-3 rounded-full bg-white hover:bg-gray-100"
-          disabled={isExcluding}
         >
           <ThumbsDown
             className="w-4 h-4 text-secondary hover:text-red-500"

--- a/src/features/recommendation/hooks/useRecommendMutation.ts
+++ b/src/features/recommendation/hooks/useRecommendMutation.ts
@@ -1,4 +1,3 @@
-import type { Store } from '@kakao-map/types/store';
 import { postRecommendExclude } from '@recommendation/api/recommendedStoresApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -11,20 +10,13 @@ export const useRecommendExcludeMutation = () => {
 
   return useMutation({
     mutationFn: (brandId: number) => postRecommendExclude(brandId),
-    onSuccess: (res, brandId) => {
+    onSuccess: res => {
       toast.success(res.message || '추천 목록에서 제외했습니다.');
 
-      // ✅ 동일 브랜드 매장을 추천 목록에서 제거
-      queryClient.setQueryData<Store[]>(
-        ['recommendStoresByLocation'],
-        oldData => {
-          if (!oldData) return [];
-          return oldData.filter(item => item.brandId !== brandId);
-        }
-      );
-    },
-    onError: () => {
-      toast.error('처리 중 오류가 발생했습니다.');
+      // 캐시 무효화 → 서버에서 최신 데이터 재요청
+      queryClient.invalidateQueries({
+        queryKey: ['recommendStoresByLocation'],
+      });
     },
   });
 };


### PR DESCRIPTION
[![UHYU-379](https://badgen.net/badge/JIRA/UHYU-379/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-379) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-379-dislike-modal)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-379-dislike-modal) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
싫어요 버튼 눌렀을때 바로 서버에 전송이 안되고, 알람창을 한번 더 띄워서 체크 여부
싫어요 버튼 눌렀을때 재요청보내서 적용된 추천카드를 적용하고자 함

# 현재 UI 캡처

|추천카드 삭제 알람 모달창|
|:--:|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/9e82827a-12f7-4b58-8f14-aaff3c93e361" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-379]: https://u-hyu.atlassian.net/browse/UHYU-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 브랜드 추천 제외 시, 확인 모달이 표시되어 사용자가 제외를 확정할 수 있도록 변경되었습니다.

* **버그 수정**
  * 추천 제외 시 즉시 처리되던 동작이 모달을 통한 사용자 확인 후 처리로 개선되었습니다.

* **기타 개선**
  * 추천 제외 후 데이터가 자동으로 새로고침되어 최신 상태가 반영됩니다.  
  * 오류 메시지 토스트가 더 이상 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->