### PR TITLE
[FEAT][UHYU-384] 지도 줌 레벨 사용자 UI + 줌 레벨 별 반경 검색 기능 구현 ( 메뉴얼 버튼 연동 )

### DIFF
--- a/src/features/barcode/components/VisitConfirmSection.tsx
+++ b/src/features/barcode/components/VisitConfirmSection.tsx
@@ -20,7 +20,6 @@ const VisitConfirmSection = ({ store, onConfirm, onReject }: StoreProps) => {
 
     confirmVisit(store.storeId, {
       onSuccess: () => {
-        console.log(`${store.storeName} 방문 처리 완료`);
         onConfirm();
       },
       onError: () => {

--- a/src/features/kakao-map/components/ManualSearchButton.tsx
+++ b/src/features/kakao-map/components/ManualSearchButton.tsx
@@ -13,6 +13,8 @@ interface ManualSearchButtonProps {
   distance?: number;
   /** 추가 CSS 클래스 */
   className?: string;
+  zoomLevel?: number;
+  radius?: number; // meter
 }
 
 /**
@@ -25,6 +27,8 @@ export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
   onClick,
   distance,
   className = '',
+  zoomLevel,
+  radius,
 }) => {
   if (!visible) return null;
 
@@ -76,6 +80,15 @@ export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
         {distance && (
           <span className="text-xs text-gray-500 ml-1">
             ({Math.round(distance)}m)
+          </span>
+        )}
+
+        {(typeof zoomLevel === 'number' || typeof radius === 'number') && (
+          <span className="text-xs text-gray-500 ml-2">
+            {typeof zoomLevel === 'number'}
+            {typeof radius === 'number' && (
+              <>{Math.round(radius / 1000)}km 반경</>
+            )}
           </span>
         )}
       </button>

--- a/src/features/kakao-map/components/ManualSearchButton.tsx
+++ b/src/features/kakao-map/components/ManualSearchButton.tsx
@@ -77,7 +77,7 @@ export const ManualSearchButton: React.FC<ManualSearchButtonProps> = ({
         </span>
 
         {/* 이동 거리 표시 */}
-        {distance && (
+        {typeof distance === 'number' && distance > 0 && (
           <span className="text-xs text-gray-500 ml-1">
             ({Math.round(distance)}m)
           </span>

--- a/src/features/kakao-map/components/MapContainer.tsx
+++ b/src/features/kakao-map/components/MapContainer.tsx
@@ -18,6 +18,7 @@ interface MapContainerProps {
     setMapCenter: (center: { lat: number; lng: number }) => void
   ) => void;
   onMapCenterChange?: (center: { lat: number; lng: number }) => void;
+  onMapCreate?: (map: kakao.maps.Map) => void;
 }
 
 export const MapContainer: React.FC<MapContainerProps> = ({
@@ -27,6 +28,7 @@ export const MapContainer: React.FC<MapContainerProps> = ({
   onPlaceInfoClose,
   onMapCenterUpdate,
   onMapCenterChange,
+  onMapCreate,
 }) => {
   const { stores, mapCenter, userLocation, loading, setMapCenter } =
     useMapData();
@@ -34,6 +36,9 @@ export const MapContainer: React.FC<MapContainerProps> = ({
     useMapInteraction();
   const { bottomSheetRef } = useMapUIContext();
   const { activeCategoryFilter } = useMapUI();
+
+  // 지도 인스턴스를 저장할 ref
+  const [map, setMap] = React.useState<kakao.maps.Map | null>(null);
 
   // 매장 데이터는 이미 useMapData에서 백엔드 API를 통해 필터링됨
   // 추가 프론트엔드 필터링 불필요
@@ -149,6 +154,11 @@ export const MapContainer: React.FC<MapContainerProps> = ({
       onCenterChange={handleMapCenterChange}
       isSearching={loading.stores}
       selectedStoreId={selectedMarkerId}
+      onMapCreate={(mapInstance) => {
+        setMap(mapInstance);
+        onMapCreate?.(mapInstance);
+      }}
+      map={map}
     />
   );
 };

--- a/src/features/kakao-map/components/MapControlsContainer.tsx
+++ b/src/features/kakao-map/components/MapControlsContainer.tsx
@@ -24,6 +24,8 @@ interface MapControlsContainerProps {
   mapCenter?: { lat: number; lng: number };
   /** 검색 결과를 유지한 채로 아이템 선택 (검색창은 닫지 않음) */
   onSearchResultItemClick?: (place: NormalizedPlace) => void;
+  /** 지도 인스턴스 (줌 레벨 표시용) */
+  map?: kakao.maps.Map | null;
 }
 
 /**
@@ -41,6 +43,7 @@ export const MapControlsContainer: React.FC<MapControlsContainerProps> = ({
   debounceDelay = Number(import.meta.env.VITE_SEARCH_DEBOUNCE_DELAY) || 500,
   mapCenter,
   onSearchResultItemClick,
+  map,
 }) => {
   // UI 상태와 액션들 가져오기
   const {
@@ -258,6 +261,7 @@ export const MapControlsContainer: React.FC<MapControlsContainerProps> = ({
         onCloseSearchResults={handleCloseSearchResults}
         searchMeta={meta}
         hasSearched={hasSearched}
+        map={map}
       />
       <MapButtonsContainer />
     </div>

--- a/src/features/kakao-map/components/layout/MapTopControls.tsx
+++ b/src/features/kakao-map/components/layout/MapTopControls.tsx
@@ -4,9 +4,13 @@ import RegionFilterDropdown from '@kakao-map/components/layout/RegionFilterDropd
 
 import { FilterTabs } from '@/shared/components';
 
-import type { NormalizedPlace, KakaoKeywordSearchResponse } from '../../api/types';
+import type {
+  KakaoKeywordSearchResponse,
+  NormalizedPlace,
+} from '../../api/types';
 import { MapSearchInput } from '../search/MapSearchInput';
 import { SearchResultList } from '../search/SearchResultList';
+import { MapZoomLevelIndicator } from '../ui/MapZoomLevelIndicator';
 import BottomSheetToggleButton from './BottomSheetToggleButton';
 
 /**
@@ -47,6 +51,8 @@ interface MapTopControlsProps {
   searchMeta?: KakaoKeywordSearchResponse['meta'] | null;
   /** 검색이 실행되었는지 여부 */
   hasSearched?: boolean;
+  /** 지도 인스턴스 (줌 레벨 표시용) */
+  map?: kakao.maps.Map | null;
 }
 
 /**
@@ -72,10 +78,14 @@ const MapTopControls: FC<MapTopControlsProps> = ({
   onCloseSearchResults,
   searchMeta,
   hasSearched = false,
+  map,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   // 검색 중이거나, 검색 결과가 있거나, 검색이 완료되었지만 결과가 없는 경우 표시
-  const isSearchResultsVisible = isSearching || keywordResults.length > 0 || (hasSearched && keywordResults.length === 0);
+  const isSearchResultsVisible =
+    isSearching ||
+    keywordResults.length > 0 ||
+    (hasSearched && keywordResults.length === 0);
 
   // 외부 클릭 시 검색 결과 닫기
   useEffect(() => {
@@ -155,10 +165,12 @@ const MapTopControls: FC<MapTopControlsProps> = ({
 
       {/* 하단 라인: 카테고리 필터탭 전체 너비 사용 */}
       <div className="-mx-4 overflow-x-auto">
-        <FilterTabs 
-          variant="white" 
-          onChange={onCategoryFilterChange}
-        />
+        <FilterTabs variant="white" onChange={onCategoryFilterChange} />
+      </div>
+
+      {/* 줌 레벨 표시 UI - 필터탭 아래에 위치 */}
+      <div className="flex justify-start">
+        <MapZoomLevelIndicator map={map ?? null} />
       </div>
 
       {/* 검색 결과 리스트 */}

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 
+import { useZoomSearchTrigger } from '@kakao-map/hooks/useZoomSearchTrigger';
 import {
   useMapStore,
   useRecommendedStores,
@@ -40,7 +41,7 @@ interface MapWithMarkersProps {
   keywordResults?: NormalizedPlace[];
   selectedPlace?: NormalizedPlace | null;
   currentLocation?: { lat: number; lng: number } | null;
-  level?: number;
+  level?: number; // 초기값으로만 사용하고, 비제어로 전환
   className?: string;
   onStoreClick?: (store: Store) => void;
   onPlaceClick?: (place: NormalizedPlace) => void;
@@ -62,7 +63,6 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   keywordResults = [],
   selectedPlace,
   currentLocation,
-  level = 4,
   className = 'w-full h-full',
   onStoreClick,
   onPlaceClick,
@@ -83,6 +83,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   const [isPanto, setIsPanto] = useState(false);
   const mapRef = useRef<kakao.maps.Map | null>(null);
   const pantoTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const didInitZoomSyncRef = useRef(false);
   const refreshBookmarkStores = useRefreshBookmarkStores();
 
   // 내부 상태 정의(mymap)
@@ -100,30 +101,27 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
 
   const { bookmarkMode, bookmarkStores, selectStore } = useMapStore();
 
-  const ensureMinZoomOnce = (map: kakao.maps.Map | null, minLevel = 6) => {
-    if (!map) return;
-    const curr = map.getLevel();
-    // 숫자가 클수록 더 멀리(축소) — 너무 멀면 한 번만 가까이
-    if (curr > minLevel) map.setLevel(minLevel);
-  };
+  const ensureMinZoomOnce = useCallback(
+    (map: kakao.maps.Map | null, minLevel = 6) => {
+      if (!map) return;
+      const curr = map.getLevel();
+      // 숫자가 클수록 더 멀리(축소)
+      if (curr > minLevel) map.setLevel(minLevel);
+    },
+    []
+  );
 
-  // 마커에 사용할 store 배열 결정(mymap)
-  // const storesToRender = isShared ? sharedStores : stores;
   // 마커에 사용할 store 배열 결정 (일반 매장 + 추천 매장)
   const storesToRender = useMemo(() => {
     if (isShared) return sharedStores;
 
-    // 일반 매장과 추천 매장을 합치되, 중복 제거
     const allStores = [...stores];
-
     if (showRecommendedStores && recommendedStores.length > 0) {
       recommendedStores.forEach(recommendedStore => {
         const exists = allStores.some(
           store => store.storeId === recommendedStore.storeId
         );
-        if (!exists) {
-          allStores.push(recommendedStore);
-        }
+        if (!exists) allStores.push(recommendedStore);
       });
     }
     return allStores;
@@ -147,15 +145,49 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   // 인증 확인 및 로그인 모달 관리
   const { checkAuthAndExecuteModal } = useAuthCheckModal();
 
+  const setZoomLevel = useMapStore(state => state.setZoomLevel);
+
+  const handleZoomChanged = useCallback(
+    (map: kakao.maps.Map) => {
+      const lv = map.getLevel();
+      setZoomLevel(lv); // MapStore가 searchRadius도 함께 업데이트
+    },
+    [setZoomLevel]
+  );
+
+  // 줌 기반 버튼 표시 훅
+  const { visibleByZoom, currentZoomLevel, currentRadius, markSearched } =
+    useZoomSearchTrigger({ levelDeltaThreshold: 1 });
+
+  // 재검색 버튼 클릭 (거리 + 줌 기준 동시 갱신)
+  const handleSearchClick = useCallback(() => {
+    if (!onCenterChange || !mapRef.current) return;
+    const c = mapRef.current.getCenter();
+    if (!c) return;
+
+    const pos = { lat: c.getLat(), lng: c.getLng() };
+
+    // 거리 기반 기준 갱신 + API
+    handleSearch();
+    updateSearchPosition(pos);
+    onCenterChange(pos);
+
+    // 줌 기준 갱신
+    markSearched();
+  }, [onCenterChange, handleSearch, updateSearchPosition, markSearched]);
+
   // center prop 동기화 및 검색 기준 위치 설정 (인포윈도우 상태 변경 시 의존성 제외)
   useEffect(() => {
-    // 인포윈도우가 열려있지 않을 때만 center prop 동기화
     if (!infoWindowStore && !recommendedInfoWindowStore) {
       setMapCenter(center);
-      // 새로운 center가 설정될 때 검색 기준 위치도 업데이트
       updateSearchPosition(center);
     }
-  }, [center, updateSearchPosition]);
+  }, [
+    center,
+    updateSearchPosition,
+    infoWindowStore,
+    recommendedInfoWindowStore,
+  ]);
 
   // 전역 selectedStore 변경 시 해당 매장으로 포커스 (카드 클릭 시)
   useEffect(() => {
@@ -164,48 +196,40 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
       const targetStore = storesToRender.find(
         store => store.storeId === globalSelectedStore.storeId
       );
-
       if (targetStore) {
-        // 기존 인포윈도우들 닫기
         setInfoWindowStore(null);
         setRecommendedInfoWindowStore(null);
 
-        // 추천 매장인지 확인하여 적절한 인포윈도우 표시
         const isRecommended = recommendedStores.some(
           store => store.storeId === targetStore.storeId
         );
+        if (isRecommended) setRecommendedInfoWindowStore(targetStore);
+        else setInfoWindowStore(targetStore);
 
-        if (isRecommended) {
-          setRecommendedInfoWindowStore(targetStore);
-        } else {
-          setInfoWindowStore(targetStore);
-        }
-
-        // 지도 중심을 해당 매장으로 이동
         const offset = 0.0017;
-        const targetLat = targetStore.latitude + offset;
-        const targetLng = targetStore.longitude;
-        const targetCenter = { lat: targetLat, lng: targetLng };
+        const targetCenter = {
+          lat: targetStore.latitude + offset,
+          lng: targetStore.longitude,
+        };
 
         setIsPanto(true);
         setMapCenter(targetCenter);
 
-        // 지도 레벨을 4로 변경 (바텀시트에서 매장 선택시)
-        if (mapRef.current) {
-          ensureMinZoomOnce(mapRef.current, 6);
-        }
+        if (mapRef.current) ensureMinZoomOnce(mapRef.current, 6);
 
-        if (pantoTimeoutRef.current) {
-          clearTimeout(pantoTimeoutRef.current);
-        }
-
+        if (pantoTimeoutRef.current) clearTimeout(pantoTimeoutRef.current);
         pantoTimeoutRef.current = setTimeout(() => {
           setIsPanto(false);
           pantoTimeoutRef.current = null;
         }, 500);
       }
     }
-  }, [globalSelectedStoreId, storesToRender, recommendedStores]);
+  }, [
+    globalSelectedStoreId,
+    storesToRender,
+    recommendedStores,
+    ensureMinZoomOnce,
+  ]);
 
   // 외부에서 selectedStoreId가 변경될 때 인포윈도우 표시
   useEffect(() => {
@@ -214,111 +238,89 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         store => store.storeId === externalSelectedStoreId
       );
       if (selectedStore) {
-        // 추천 매장인지 확인
         const isRecommended = recommendedStores.some(
           store => store.storeId === selectedStore.storeId
         );
-        // 기존 인포윈도우들 닫기
+
         setInfoWindowStore(null);
         setRecommendedInfoWindowStore(null);
+        if (isRecommended) setRecommendedInfoWindowStore(selectedStore);
+        else setInfoWindowStore(selectedStore);
 
-        // 해당 스토어 인포윈도우 표시
-        if (isRecommended) {
-          setRecommendedInfoWindowStore(selectedStore);
-        } else {
-          setInfoWindowStore(selectedStore);
-        }
-
-        // 지도 중심을 해당 매장으로 이동
         const offset = 0.0017;
-        const targetLat = selectedStore.latitude + offset;
-        const targetLng = selectedStore.longitude;
-        const targetCenter = { lat: targetLat, lng: targetLng };
+        const targetCenter = {
+          lat: selectedStore.latitude + offset,
+          lng: selectedStore.longitude,
+        };
 
         setIsPanto(true);
         setMapCenter(targetCenter);
 
-        // 지도 레벨을 4로 변경
-        if (mapRef.current) {
-          ensureMinZoomOnce(mapRef.current, 6);
-        }
+        if (mapRef.current) ensureMinZoomOnce(mapRef.current, 6);
 
-        // 기존 timeout이 있다면 정리
-        if (pantoTimeoutRef.current) {
-          clearTimeout(pantoTimeoutRef.current);
-        }
-
-        // 애니메이션 완료 후 isPanto 리셋
+        if (pantoTimeoutRef.current) clearTimeout(pantoTimeoutRef.current);
         pantoTimeoutRef.current = setTimeout(() => {
           setIsPanto(false);
           pantoTimeoutRef.current = null;
         }, 500);
       }
     }
-  }, [externalSelectedStoreId, storesToRender, recommendedStores]);
+  }, [
+    externalSelectedStoreId,
+    storesToRender,
+    recommendedStores,
+    ensureMinZoomOnce,
+  ]);
 
   // 컴포넌트 언마운트 시 setTimeout cleanup
   useEffect(() => {
     return () => {
-      if (pantoTimeoutRef.current) {
-        clearTimeout(pantoTimeoutRef.current);
-      }
+      if (pantoTimeoutRef.current) clearTimeout(pantoTimeoutRef.current);
     };
   }, []);
 
   const handleMarkerClick = useCallback(
     (store: Store) => {
-      // 로그인 상태 확인 후 인포윈도우 표시
       checkAuthAndExecuteModal(() => {
         setInternalSelectedStoreId(store.storeId);
         setInfoWindowStore(store);
 
-        // 추천 매장인지 확인
         const isRecommended = recommendedStores.some(
           s => s.storeId === store.storeId
         );
-        if (isRecommended) {
-          setRecommendedInfoWindowStore(store);
-        } else {
-          setInfoWindowStore(store);
-        }
+        if (isRecommended) setRecommendedInfoWindowStore(store);
+        else setInfoWindowStore(store);
 
         trackMarkerClick(store.storeId);
 
-        // 인포 윈도우가 화면 중앙에 오도록 오프셋 적용
         const offset = 0.0017;
-        const targetLat = store.latitude + offset;
-        const targetLng = store.longitude;
-        const targetCenter = { lat: targetLat, lng: targetLng };
+        const targetCenter = {
+          lat: store.latitude + offset,
+          lng: store.longitude,
+        };
 
-        // KakaoMap의 isPanto를 사용한 부드러운 이동
         setIsPanto(true);
         setMapCenter(targetCenter);
 
-        // 지도 레벨을 4로 변경
-        if (mapRef.current) {
-          ensureMinZoomOnce(mapRef.current, 6);
-        }
+        if (mapRef.current) ensureMinZoomOnce(mapRef.current, 6);
 
-        // 기존 timeout이 있다면 정리
-        if (pantoTimeoutRef.current) {
-          clearTimeout(pantoTimeoutRef.current);
-        }
-
-        // 애니메이션 완료 후 isPanto 리셋
+        if (pantoTimeoutRef.current) clearTimeout(pantoTimeoutRef.current);
         pantoTimeoutRef.current = setTimeout(() => {
           setIsPanto(false);
           pantoTimeoutRef.current = null;
-        }, 500); // 애니메이션 시간을 500ms로 증가
+        }, 500);
 
-        // 외부에서 전달받은 onStoreClick 콜백도 호출
         onStoreClick?.(store);
       });
     },
-    [onStoreClick, recommendedStores, checkAuthAndExecuteModal]
+    [
+      onStoreClick,
+      recommendedStores,
+      checkAuthAndExecuteModal,
+      ensureMinZoomOnce,
+    ]
   );
 
-  // 추천 매장인지 확인하는 함수
   const isRecommendedStore = useCallback(
     (storeId: number) => {
       return recommendedStores.some(store => store.storeId === storeId);
@@ -330,32 +332,25 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
     setInternalSelectedStoreId(null);
     setInfoWindowStore(null);
     setRecommendedInfoWindowStore(null);
-    // 전역 상태 초기화 시 지도 중심점 이동 방지
     selectStore(null);
-  }, []);
+  }, [selectStore]);
 
   const toggleFavoriteMutation = useToggleFavoriteMutation();
 
   const handleToggleFavorite = useCallback(
     async (event?: React.MouseEvent) => {
-      // 이벤트 전파 차단 (추가 보호)
       if (event) {
         event.stopPropagation();
         event.preventDefault();
       }
-
       if (!infoWindowStore) return;
 
-      // 로그인 상태 확인 후 즐겨찾기 토글 실행
       checkAuthAndExecuteModal(async () => {
         try {
           await toggleFavoriteMutation.mutateAsync({
             storeId: infoWindowStore.storeId,
           });
-
-          if (bookmarkMode) {
-            refreshBookmarkStores();
-          }
+          if (bookmarkMode) refreshBookmarkStores();
         } catch (error) {
           console.error('즐겨찾기 토글 실패:', error);
         }
@@ -379,36 +374,19 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         lat: newCenter.getLat(),
         lng: newCenter.getLng(),
       };
-
-      // 거리 기반 재검색 상태 업데이트만 실행 (자동 검색 로직 제거)
       handleMapMove(currentPosition);
     },
     [handleMapMove]
   );
 
-  /**
-   * 재검색 버튼 클릭 핸들러
-   */
-  const handleSearchClick = useCallback(() => {
-    if (!onCenterChange || !mapRef.current) return;
+  // 최초 1회: onCreate 이후 현재 줌 레벨을 스토어와 동기화 (무한 루프 방지)
+  useEffect(() => {
+    if (!mapRef.current || didInitZoomSyncRef.current) return;
+    didInitZoomSyncRef.current = true;
+    setZoomLevel(mapRef.current.getLevel());
+  }, [setZoomLevel]);
 
-    const currentCenter = mapRef.current.getCenter();
-    if (!currentCenter) return;
-
-    const currentPosition = {
-      lat: currentCenter.getLat(),
-      lng: currentCenter.getLng(),
-    };
-
-    // 검색 상태 업데이트 (버튼 숨김 및 새로운 기준점 설정)
-    handleSearch();
-    updateSearchPosition(currentPosition);
-
-    // API 요청 실행
-    onCenterChange(currentPosition);
-  }, [onCenterChange, handleSearch, updateSearchPosition]);
-
-  // 중복 제거: 즐겨찾기 모드일 때 일반 마커에서 즐겨찾기 매장은 제외
+  // 즐겨찾기 모드일 때 일반 마커에서 즐겨찾기 매장은 제외
   const filteredStoresToRender = useMemo(() => {
     if (bookmarkMode) {
       const bookmarkIds = new Set(bookmarkStores.map(s => s.storeId));
@@ -417,27 +395,34 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
     return storesToRender;
   }, [storesToRender, bookmarkMode, bookmarkStores]);
 
+  const showManualButton = showButton || visibleByZoom;
+
   return (
     <>
-      {/* 거리 기반 재검색 버튼 */}
+      {/* 거리/줌 기반 재검색 버튼 */}
       <ResponsiveManualSearchButton
-        visible={showButton}
+        visible={showManualButton}
         loading={isSearching}
         onClick={handleSearchClick}
         distance={distanceFromLastSearch}
+        zoomLevel={currentZoomLevel}
+        radius={currentRadius}
       />
 
       <KakaoMap
         id="map"
         center={mapCenter}
         className={className}
-        level={level}
         isPanto={isPanto}
         onDragEnd={handleDragEnd}
-        onClick={handleInfoWindowClose} // 지도 클릭 시 인포윈도우 닫기
+        onClick={handleInfoWindowClose}
+        onZoomChanged={handleZoomChanged}
         onCreate={map => {
           mapRef.current = map;
           onMapCreate?.(map);
+          // 여기에서는 상태 업데이트 하지 않음 (무한 루프 방지)
+          // 초기 레벨을 강제하고 싶다면 아래처럼 1회만:
+          // if (typeof level === 'number') map.setLevel(level);
         }}
       >
         {/* 매장 마커들 */}
@@ -516,18 +501,14 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
                 <KeywordMarker
                   place={place}
                   onClick={clickedPlace => {
-                    // 마커 클릭 시 지도 이동 애니메이션 적용
                     if (mapRef.current) {
                       const offset = 0.0017;
                       const targetLat = clickedPlace.latitude + offset;
                       const targetLng = clickedPlace.longitude;
-
-                      // 부드러운 이동을 위해 panTo 사용
                       mapRef.current.panTo(
                         new kakao.maps.LatLng(targetLat, targetLng)
                       );
                     }
-
                     onPlaceClick?.(clickedPlace);
                   }}
                   isSelected={selectedPlace?.id === place.id}

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -48,6 +48,10 @@ interface MapWithMarkersProps {
   isSearching?: boolean;
   /** 외부에서 제어하는 선택된 매장 ID */
   selectedStoreId?: number | null;
+  /** 지도 생성 콜백 */
+  onMapCreate?: (map: kakao.maps.Map) => void;
+  /** 지도 인스턴스 */
+  map?: kakao.maps.Map | null;
 }
 
 const MapWithMarkers: FC<MapWithMarkersProps> = ({
@@ -64,6 +68,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   onCenterChange,
   isSearching = false,
   selectedStoreId: externalSelectedStoreId,
+  onMapCreate,
 }) => {
   const [internalSelectedStoreId, setInternalSelectedStoreId] = useState<
     number | null
@@ -413,6 +418,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         distance={distanceFromLastSearch}
       />
 
+
       <KakaoMap
         id="map"
         center={mapCenter}
@@ -423,6 +429,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         onClick={handleInfoWindowClose} // 지도 클릭 시 인포윈도우 닫기
         onCreate={map => {
           mapRef.current = map;
+          onMapCreate?.(map);
         }}
       >
         {/* 매장 마커들 */}
@@ -541,6 +548,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
             <CurrentLocationMarker size="medium" animated={true} />
           </CustomOverlayMap>
         )}
+        
       </KakaoMap>
     </>
   );

--- a/src/features/kakao-map/components/marker/MapWithMarkers.tsx
+++ b/src/features/kakao-map/components/marker/MapWithMarkers.tsx
@@ -1,19 +1,25 @@
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
-
-
-import { useMapStore, useRecommendedStores, useRefreshBookmarkStores, useShowRecommendedStores } from '@kakao-map/store/MapStore';
+import {
+  useMapStore,
+  useRecommendedStores,
+  useRefreshBookmarkStores,
+  useShowRecommendedStores,
+} from '@kakao-map/store/MapStore';
 import { useSharedMapStore } from '@mymap/store/SharedMapStore';
 import { RecommendStoreInfoWindow } from '@recommendation/components/StoreInfoWindow';
 import { CustomOverlayMap, Map as KakaoMap } from 'react-kakao-maps-sdk';
 import { useParams } from 'react-router-dom';
 
-
-
 import { useAuthCheckModal } from '@/shared/hooks/useAuthCheckModal';
 import { trackMarkerClick } from '@/shared/utils/actionlogTracker';
-
-
 
 import type { NormalizedPlace } from '../../api/types';
 import { useDistanceBasedSearch } from '../../hooks/useManualSearch';
@@ -27,10 +33,6 @@ import { KeywordInfoWindow } from './KeywordInfoWindow';
 import { KeywordMarker } from './KeywordMarker';
 import MyMapMarker from './MyMapMarker';
 import StoreInfoWindow from './StoreInfoWindow';
-
-
-
-
 
 interface MapWithMarkersProps {
   center: { lat: number; lng: number };
@@ -97,6 +99,13 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
   );
 
   const { bookmarkMode, bookmarkStores, selectStore } = useMapStore();
+
+  const ensureMinZoomOnce = (map: kakao.maps.Map | null, minLevel = 6) => {
+    if (!map) return;
+    const curr = map.getLevel();
+    // 숫자가 클수록 더 멀리(축소) — 너무 멀면 한 번만 가까이
+    if (curr > minLevel) map.setLevel(minLevel);
+  };
 
   // 마커에 사용할 store 배열 결정(mymap)
   // const storesToRender = isShared ? sharedStores : stores;
@@ -183,7 +192,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
 
         // 지도 레벨을 4로 변경 (바텀시트에서 매장 선택시)
         if (mapRef.current) {
-          mapRef.current.setLevel(4);
+          ensureMinZoomOnce(mapRef.current, 6);
         }
 
         if (pantoTimeoutRef.current) {
@@ -231,7 +240,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
 
         // 지도 레벨을 4로 변경
         if (mapRef.current) {
-          mapRef.current.setLevel(4);
+          ensureMinZoomOnce(mapRef.current, 6);
         }
 
         // 기존 timeout이 있다면 정리
@@ -288,7 +297,7 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
 
         // 지도 레벨을 4로 변경
         if (mapRef.current) {
-          mapRef.current.setLevel(4);
+          ensureMinZoomOnce(mapRef.current, 6);
         }
 
         // 기존 timeout이 있다면 정리
@@ -417,7 +426,6 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
         onClick={handleSearchClick}
         distance={distanceFromLastSearch}
       />
-
 
       <KakaoMap
         id="map"
@@ -548,7 +556,6 @@ const MapWithMarkers: FC<MapWithMarkersProps> = ({
             <CurrentLocationMarker size="medium" animated={true} />
           </CustomOverlayMap>
         )}
-        
       </KakaoMap>
     </>
   );

--- a/src/features/kakao-map/components/marker/MyMapMarker.tsx
+++ b/src/features/kakao-map/components/marker/MyMapMarker.tsx
@@ -14,7 +14,7 @@ const MyMapMarker: FC<MyMapMarkerProps> = ({ isSelected = false, onClick }) => {
   const markerColor = useSharedMapStore(state => state.markerColor);
   const markerColorClass =
     MYMAP_COLOR_BG[markerColor as MarkerColor] ?? MYMAP_COLOR_BG.RED;
-  console.log(`즐겨찾기색: ${markerColorClass}`);
+  // console.log(`즐겨찾기색: ${markerColorClass}`);
 
   return (
     <div className="relative" onClick={onClick}>

--- a/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
+++ b/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { Minus, Plus, ZoomIn, ZoomOut } from 'lucide-react';
+
+import { useMapStore, useSearchRadius, useZoomLevel } from '../../store/MapStore';
 
 // 줌 레벨에 따른 검색 반경 계산 (줌 레벨 4를 5km 기준으로 설정)
 export const getSearchRadiusByZoomLevel = (zoomLevel: number): number => {
@@ -22,17 +24,21 @@ interface MapZoomLevelIndicatorProps {
  * @param map - 카카오 지도 인스턴스
  */
 export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
-  const [zoomLevel, setZoomLevel] = useState<number>(4);
+  // MapStore에서 줌 레벨과 검색 반경 상태 구독
+  const zoomLevel = useZoomLevel();
+  const searchRadius = useSearchRadius();
+  const setZoomLevel = useMapStore(state => state.setZoomLevel);
 
   useEffect(() => {
     if (!map) {
-      setZoomLevel(4); // 기본값
       return;
     }
 
-    // 초기 줌 레벨 설정
+    // 초기 줌 레벨을 MapStore와 동기화
     const currentLevel = map.getLevel();
-    setZoomLevel(currentLevel);
+    if (currentLevel !== zoomLevel) {
+      setZoomLevel(currentLevel);
+    }
 
     // 줌 레벨 변경 이벤트 리스너
     const handleZoomChanged = () => {
@@ -47,7 +53,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
     return () => {
       kakao.maps.event.removeListener(map, 'zoom_changed', handleZoomChanged);
     };
-  }, [map]);
+  }, [map, zoomLevel, setZoomLevel]);
 
   // 줌 인 (확대) 핸들러
   const handleZoomIn = () => {
@@ -83,7 +89,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
               줌 레벨 {zoomLevel}
             </span>
             <span className="text-xs text-gray leading-tight">
-              {getSearchRadiusByZoomLevel(zoomLevel) / 1000}km 반경 매장
+              {searchRadius / 1000}km 반경 매장
             </span>
           </div>
         </div>

--- a/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
+++ b/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 
-import { ZoomIn, ZoomOut } from 'lucide-react';
+import { Minus, Plus, ZoomIn, ZoomOut } from 'lucide-react';
 
 // 줌 레벨에 따른 검색 반경 계산 (줌 레벨 4를 5km 기준으로 설정)
 export const getSearchRadiusByZoomLevel = (zoomLevel: number): number => {
-  if (zoomLevel <= 3) return 20000; // 20km - 매우 넓은 지역
-  if (zoomLevel <= 5) return 10000; // 10km - 넓은 지역
-  if (zoomLevel <= 4) return 1000; // 1km - 일반 지역
-  if (zoomLevel <= 9) return 2000; // 2km - 상세 지역
-  if (zoomLevel <= 11) return 1000; // 1km - 매우 상세
-  return 500; // 500m - 최대 확대
+  if (zoomLevel <= 4) return 1000;
+  if (zoomLevel <= 5) return 2000;
+  if (zoomLevel <= 6) return 4000;
+  if (zoomLevel <= 7) return 8000;
+  if (zoomLevel <= 8) return 20000;
+  return 20000; // 1000m - 최대 확대
 };
 
 interface MapZoomLevelIndicatorProps {
@@ -17,7 +17,7 @@ interface MapZoomLevelIndicatorProps {
 }
 
 /**
- * 지도의 현재 줌 레벨을 표시하는 UI 컴포넌트
+ * 지도의 현재 줌 레벨을 표시하고 확대/축소 컨트롤을 제공하는 UI 컴포넌트
  *
  * @param map - 카카오 지도 인스턴스
  */
@@ -49,20 +49,66 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
     };
   }, [map]);
 
+  // 줌 인 (확대) 핸들러
+  const handleZoomIn = () => {
+    if (!map) return;
+    const currentLevel = map.getLevel();
+    if (currentLevel > 1) {
+      // 카카오맵 최대 확대 레벨은 1
+      map.setLevel(currentLevel - 1);
+    }
+  };
+
+  // 줌 아웃 (축소) 핸들러
+  const handleZoomOut = () => {
+    if (!map) return;
+    const currentLevel = map.getLevel();
+    if (currentLevel < 14) {
+      // 카카오맵 최대 축소 레벨은 14
+      map.setLevel(currentLevel + 1);
+    }
+  };
+
   // 줌 레벨에 따른 아이콘 선택
   const ZoomIcon = zoomLevel <= 7 ? ZoomOut : ZoomIn;
 
   return (
-    <div className="bg-white/95 backdrop-blur-sm border border-light-gray rounded-lg px-3 py-2 shadow-sm">
-      <div className="flex items-center gap-2">
-        <ZoomIcon className="w-4 h-4 text-primary" />
-        <div className="flex flex-col">
-          <span className="text-xs font-medium text-black">
-            줌 레벨 {zoomLevel}
-          </span>
-          <span className="text-xs text-gray">
-            {getSearchRadiusByZoomLevel(zoomLevel) / 1000}km 반경 내 매장 검색
-          </span>
+    <div className="bg-white/95 backdrop-blur-sm border border-light-gray rounded-lg shadow-sm overflow-hidden">
+      <div className="flex items-center">
+        {/* 줌 레벨 정보 */}
+        <div className="flex items-center gap-2 px-2.5 py-2">
+          <ZoomIcon className="w-3.5 h-3.5 text-primary flex-shrink-0" />
+          <div className="flex flex-col">
+            <span className="text-xs font-medium text-black leading-tight">
+              줌 레벨 {zoomLevel}
+            </span>
+            <span className="text-xs text-gray leading-tight">
+              {getSearchRadiusByZoomLevel(zoomLevel) / 1000}km 반경 매장
+            </span>
+          </div>
+        </div>
+
+        {/* 확대/축소 버튼 컨테이너 */}
+        <div className="flex flex-col border-l border-light-gray">
+          {/* 확대 버튼 */}
+          <button
+            onClick={handleZoomIn}
+            disabled={zoomLevel <= 1}
+            className="flex items-center justify-center w-7 h-5 hover:bg-primary hover:text-white transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-inherit border-b border-light-gray"
+            aria-label="지도 확대"
+          >
+            <Plus className="w-3 h-3" />
+          </button>
+
+          {/* 축소 버튼 */}
+          <button
+            onClick={handleZoomOut}
+            disabled={zoomLevel >= 14}
+            className="flex items-center justify-center w-7 h-5 hover:bg-primary hover:text-white transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-inherit"
+            aria-label="지도 축소"
+          >
+            <Minus className="w-3 h-3" />
+          </button>
         </div>
       </div>
     </div>

--- a/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
+++ b/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+import { ZoomIn, ZoomOut } from 'lucide-react';
+
+// 줌 레벨에 따른 검색 반경 계산 (줌 레벨 4를 5km 기준으로 설정)
+export const getSearchRadiusByZoomLevel = (zoomLevel: number): number => {
+  if (zoomLevel <= 3) return 20000; // 20km - 매우 넓은 지역
+  if (zoomLevel <= 5) return 10000; // 10km - 넓은 지역
+  if (zoomLevel <= 4) return 1000; // 1km - 일반 지역
+  if (zoomLevel <= 9) return 2000; // 2km - 상세 지역
+  if (zoomLevel <= 11) return 1000; // 1km - 매우 상세
+  return 500; // 500m - 최대 확대
+};
+
+interface MapZoomLevelIndicatorProps {
+  map: kakao.maps.Map | null;
+}
+
+/**
+ * 지도의 현재 줌 레벨을 표시하는 UI 컴포넌트
+ *
+ * @param map - 카카오 지도 인스턴스
+ */
+export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
+  const [zoomLevel, setZoomLevel] = useState<number>(4);
+
+  useEffect(() => {
+    if (!map) {
+      setZoomLevel(4); // 기본값
+      return;
+    }
+
+    // 초기 줌 레벨 설정
+    const currentLevel = map.getLevel();
+    setZoomLevel(currentLevel);
+
+    // 줌 레벨 변경 이벤트 리스너
+    const handleZoomChanged = () => {
+      const newLevel = map.getLevel();
+      setZoomLevel(newLevel);
+    };
+
+    // 이벤트 리스너 등록
+    kakao.maps.event.addListener(map, 'zoom_changed', handleZoomChanged);
+
+    // 클린업
+    return () => {
+      kakao.maps.event.removeListener(map, 'zoom_changed', handleZoomChanged);
+    };
+  }, [map]);
+
+  // 줌 레벨에 따른 아이콘 선택
+  const ZoomIcon = zoomLevel <= 7 ? ZoomOut : ZoomIn;
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm border border-light-gray rounded-lg px-3 py-2 shadow-sm">
+      <div className="flex items-center gap-2">
+        <ZoomIcon className="w-4 h-4 text-primary" />
+        <div className="flex flex-col">
+          <span className="text-xs font-medium text-black">
+            줌 레벨 {zoomLevel}
+          </span>
+          <span className="text-xs text-gray">
+            {getSearchRadiusByZoomLevel(zoomLevel) / 1000}km 반경 내 매장 검색
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
+++ b/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
@@ -42,7 +42,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
     return () => {
       kakao.maps.event.removeListener(map, 'zoom_changed', handleZoomChanged);
     };
-  }, [map, zoomLevel, setZoomLevel]);
+  });
 
   const handleZoomIn = () => {
     if (!map) return;
@@ -59,7 +59,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
   const ZoomIcon = zoomLevel <= 7 ? ZoomOut : ZoomIn;
 
   return (
-    <div className="flex flex-col gap-2 min-w-[100px] md:min-w-[160px]">
+    <div className="flex flex-col gap-2">
       {/* 인포 박스 */}
       <div
         className="
@@ -85,7 +85,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
       {/* 컨트롤 박스 (인포 하단) */}
       <div
         className="
-        w-1/2
+          w-1/2
           bg-white/95 backdrop-blur-sm border border-light-gray
           rounded-xl shadow-sm overflow-hidden
         "
@@ -99,7 +99,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
           disabled={zoomLevel <= 1}
           aria-label="지도 확대"
           className="
-            w-full h-14 md:h-16
+            w-full h-14 md:h-14
             flex items-center justify-center
             hover:bg-primary hover:text-white
             transition-colors
@@ -121,7 +121,7 @@ export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
           disabled={zoomLevel >= 14}
           aria-label="지도 축소"
           className="
-            w-full h-14 md:h-16
+            w-full h-12 md:h-12
             flex items-center justify-center
             hover:bg-primary hover:text-white
             transition-colors

--- a/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
+++ b/src/features/kakao-map/components/ui/MapZoomLevelIndicator.tsx
@@ -2,16 +2,20 @@ import { useEffect } from 'react';
 
 import { Minus, Plus, ZoomIn, ZoomOut } from 'lucide-react';
 
-import { useMapStore, useSearchRadius, useZoomLevel } from '../../store/MapStore';
+import {
+  useMapStore,
+  useSearchRadius,
+  useZoomLevel,
+} from '../../store/MapStore';
 
-// 줌 레벨에 따른 검색 반경 계산 (줌 레벨 4를 5km 기준으로 설정)
+// 줌 레벨 → 검색 반경
 export const getSearchRadiusByZoomLevel = (zoomLevel: number): number => {
   if (zoomLevel <= 4) return 1000;
   if (zoomLevel <= 5) return 2000;
   if (zoomLevel <= 6) return 4000;
   if (zoomLevel <= 7) return 8000;
   if (zoomLevel <= 8) return 20000;
-  return 20000; // 1000m - 최대 확대
+  return 20000;
 };
 
 interface MapZoomLevelIndicatorProps {
@@ -19,103 +23,115 @@ interface MapZoomLevelIndicatorProps {
 }
 
 /**
- * 지도의 현재 줌 레벨을 표시하고 확대/축소 컨트롤을 제공하는 UI 컴포넌트
- *
- * @param map - 카카오 지도 인스턴스
+ * 인포 영역과 확대/축소 영역 분리 렌더링(인포 하단에 컨트롤 배치)
+ * - 아이콘 크기 반응형으로 조절
+ * - 컨테이너 최소 너비 확장
  */
 export const MapZoomLevelIndicator = ({ map }: MapZoomLevelIndicatorProps) => {
-  // MapStore에서 줌 레벨과 검색 반경 상태 구독
   const zoomLevel = useZoomLevel();
   const searchRadius = useSearchRadius();
   const setZoomLevel = useMapStore(state => state.setZoomLevel);
 
   useEffect(() => {
-    if (!map) {
-      return;
-    }
-
-    // 초기 줌 레벨을 MapStore와 동기화
+    if (!map) return;
     const currentLevel = map.getLevel();
-    if (currentLevel !== zoomLevel) {
-      setZoomLevel(currentLevel);
-    }
+    if (currentLevel !== zoomLevel) setZoomLevel(currentLevel);
 
-    // 줌 레벨 변경 이벤트 리스너
-    const handleZoomChanged = () => {
-      const newLevel = map.getLevel();
-      setZoomLevel(newLevel);
-    };
-
-    // 이벤트 리스너 등록
+    const handleZoomChanged = () => setZoomLevel(map.getLevel());
     kakao.maps.event.addListener(map, 'zoom_changed', handleZoomChanged);
-
-    // 클린업
     return () => {
       kakao.maps.event.removeListener(map, 'zoom_changed', handleZoomChanged);
     };
   }, [map, zoomLevel, setZoomLevel]);
 
-  // 줌 인 (확대) 핸들러
   const handleZoomIn = () => {
     if (!map) return;
-    const currentLevel = map.getLevel();
-    if (currentLevel > 1) {
-      // 카카오맵 최대 확대 레벨은 1
-      map.setLevel(currentLevel - 1);
-    }
+    const lv = map.getLevel();
+    if (lv > 1) map.setLevel(lv - 1);
   };
 
-  // 줌 아웃 (축소) 핸들러
   const handleZoomOut = () => {
     if (!map) return;
-    const currentLevel = map.getLevel();
-    if (currentLevel < 14) {
-      // 카카오맵 최대 축소 레벨은 14
-      map.setLevel(currentLevel + 1);
-    }
+    const lv = map.getLevel();
+    if (lv < 14) map.setLevel(lv + 1);
   };
 
-  // 줌 레벨에 따른 아이콘 선택
   const ZoomIcon = zoomLevel <= 7 ? ZoomOut : ZoomIn;
 
   return (
-    <div className="bg-white/95 backdrop-blur-sm border border-light-gray rounded-lg shadow-sm overflow-hidden">
-      <div className="flex items-center">
-        {/* 줌 레벨 정보 */}
-        <div className="flex items-center gap-2 px-2.5 py-2">
-          <ZoomIcon className="w-3.5 h-3.5 text-primary flex-shrink-0" />
-          <div className="flex flex-col">
-            <span className="text-xs font-medium text-black leading-tight">
+    <div className="flex flex-col gap-2 min-w-[100px] md:min-w-[160px]">
+      {/* 인포 박스 */}
+      <div
+        className="
+          bg-white/95 backdrop-blur-sm border border-light-gray
+          rounded-xl shadow-sm px-3 py-2
+        "
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-2">
+          {/* 아이콘: 반응형 크기 */}
+          <ZoomIcon className="w-5 h-5 md:w-6 md:h-6 text-primary flex-shrink-0" />
+          <div className="flex flex-col leading-tight">
+            <span className="text-xs font-medium text-black">
               줌 레벨 {zoomLevel}
             </span>
-            <span className="text-xs text-gray leading-tight">
-              {searchRadius / 1000}km 반경 매장
+            <span className="text-xs text-gray">
+              {(searchRadius / 1000).toFixed(0)}km 반경 매장
             </span>
           </div>
         </div>
+      </div>
 
-        {/* 확대/축소 버튼 컨테이너 */}
-        <div className="flex flex-col border-l border-light-gray">
-          {/* 확대 버튼 */}
-          <button
-            onClick={handleZoomIn}
-            disabled={zoomLevel <= 1}
-            className="flex items-center justify-center w-7 h-5 hover:bg-primary hover:text-white transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-inherit border-b border-light-gray"
-            aria-label="지도 확대"
-          >
-            <Plus className="w-3 h-3" />
-          </button>
+      {/* 컨트롤 박스 (인포 하단) */}
+      <div
+        className="
+        w-1/2
+          bg-white/95 backdrop-blur-sm border border-light-gray
+          rounded-xl shadow-sm overflow-hidden
+        "
+        role="group"
+        aria-label="지도 확대/축소 컨트롤"
+      >
+        {/* 확대 */}
+        <button
+          type="button"
+          onClick={handleZoomIn}
+          disabled={zoomLevel <= 1}
+          aria-label="지도 확대"
+          className="
+            w-full h-14 md:h-16
+            flex items-center justify-center
+            hover:bg-primary hover:text-white
+            transition-colors
+            disabled:opacity-50 disabled:cursor-not-allowed
+            disabled:hover:bg-transparent disabled:hover:text-inherit
+            rounded-t-xl
+          "
+        >
+          {/* 버튼 아이콘: 반응형 크기 */}
+          <Plus className="w-6 h-6 md:w-7 md:h-7" />
+        </button>
 
-          {/* 축소 버튼 */}
-          <button
-            onClick={handleZoomOut}
-            disabled={zoomLevel >= 14}
-            className="flex items-center justify-center w-7 h-5 hover:bg-primary hover:text-white transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-inherit"
-            aria-label="지도 축소"
-          >
-            <Minus className="w-3 h-3" />
-          </button>
-        </div>
+        <div className="h-px bg-light-gray" />
+
+        {/* 축소 */}
+        <button
+          type="button"
+          onClick={handleZoomOut}
+          disabled={zoomLevel >= 14}
+          aria-label="지도 축소"
+          className="
+            w-full h-14 md:h-16
+            flex items-center justify-center
+            hover:bg-primary hover:text-white
+            transition-colors
+            disabled:opacity-50 disabled:cursor-not-allowed
+            disabled:hover:bg-transparent disabled:hover:text-inherit
+            rounded-b-xl
+          "
+        >
+          <Minus className="w-6 h-6 md:w-7 md:h-7" />
+        </button>
       </div>
     </div>
   );

--- a/src/features/kakao-map/hooks/useBrandsByCategory.ts
+++ b/src/features/kakao-map/hooks/useBrandsByCategory.ts
@@ -38,7 +38,12 @@ export const useBrandsByCategory = (categoryKey: StoreCategory | null) => {
     if (!isError || !error) return null;
 
     // Axios 에러인 경우
-    if ('response' in error && error.response && typeof error.response === 'object' && 'status' in error.response) {
+    if (
+      'response' in error &&
+      error.response &&
+      typeof error.response === 'object' &&
+      'status' in error.response
+    ) {
       const status = error.response.status;
       switch (status) {
         case 404:
@@ -126,20 +131,20 @@ export const useBrandsCategoryDebug = (categoryKey: StoreCategory | null) => {
       isEmpty: result.isEmpty,
     },
     logState: () => {
-      console.group(`🏷️ Brands by Category Debug: ${categoryKey}`);
-      console.log('Category Key:', categoryKey);
-      console.log(
-        'Category ID:',
-        categoryKey ? getCategoryId(categoryKey) : null
-      );
-      console.log('Brand Count:', result.brandCount);
-      console.log('Brands:', result.brands);
-      console.log('Loading:', result.isLoading);
-      console.log('Error:', result.isError);
-      console.log('Error Message:', result.errorMessage);
-      console.log('Is Empty:', result.isEmpty);
-      console.log('Raw Data:', result.rawData);
-      console.groupEnd();
+      // console.group(`🏷️ Brands by Category Debug: ${categoryKey}`);
+      // console.log('Category Key:', categoryKey);
+      // console.log(
+      //   'Category ID:',
+      //   categoryKey ? getCategoryId(categoryKey) : null
+      // );
+      // console.log('Brand Count:', result.brandCount);
+      // console.log('Brands:', result.brands);
+      // console.log('Loading:', result.isLoading);
+      // console.log('Error:', result.isError);
+      // console.log('Error Message:', result.errorMessage);
+      // console.log('Is Empty:', result.isEmpty);
+      // console.log('Raw Data:', result.rawData);
+      // console.groupEnd();
     },
   };
 };

--- a/src/features/kakao-map/hooks/useMapData.ts
+++ b/src/features/kakao-map/hooks/useMapData.ts
@@ -7,6 +7,7 @@ import {
   useBookmarkMode,
   useMapStore,
   useRecommendedStores,
+  useSearchRadius,
   useShowRecommendedStores,
 } from '../store/MapStore';
 import {
@@ -17,7 +18,7 @@ import {
 } from './useMapQueries';
 
 /**
- * 기본 검색 반경 (미터 단위)
+ * 기본 검색 반경 (미터 단위) - 줌 레벨 기반 검색이 비활성화되었을 때 사용
  */
 const DEFAULT_RADIUS = Number(import.meta.env.VITE_DEFAULT_RADIUS) || 5000;
 
@@ -39,6 +40,9 @@ export const useMapData = () => {
   // 추천 매장 상태 추가
   const recommendedStores = useRecommendedStores();
   const showRecommendedStores = useShowRecommendedStores();
+
+  // 줌 레벨 기반 동적 검색 반경
+  const dynamicSearchRadius = useSearchRadius();
 
   // 액션 함수들을 개별적으로 구독
   const setStoresFromQuery = useMapStore(state => state.setStoresFromQuery);
@@ -108,13 +112,13 @@ export const useMapData = () => {
 
   /**
    * 백엔드 API 호출을 위한 쿼리 파라미터 생성
-   * 지도 중심점, 필터 상태, 검색어를 종합하여 파라미터 구성
+   * 지도 중심점, 필터 상태, 검색어, 동적 검색 반경을 종합하여 파라미터 구성
    */
   const storeListParams: GetNearbyStoresParams = useMemo(() => {
     const baseParams: GetNearbyStoresParams = {
       lat: mapCenter.lat,
       lon: mapCenter.lng,
-      radius: DEFAULT_RADIUS,
+      radius: dynamicSearchRadius, // 줌 레벨 기반 동적 반경 사용
     };
 
     // 카테고리 필터 파라미터 추가 (값이 있을 때만)
@@ -132,6 +136,7 @@ export const useMapData = () => {
   }, [
     mapCenter.lat,
     mapCenter.lng,
+    dynamicSearchRadius, // 동적 검색 반경 의존성 추가
     uiState.activeCategoryFilter,
     uiState.selectedBrand,
     mapCategoryToBackend,

--- a/src/features/kakao-map/hooks/useZoomSearchTrigger.ts
+++ b/src/features/kakao-map/hooks/useZoomSearchTrigger.ts
@@ -1,0 +1,50 @@
+// features/kakao-map/hooks/useZoomSearchTrigger.ts
+import { useEffect, useRef, useState } from 'react';
+
+import { useSearchRadius, useZoomLevel } from '../store/MapStore';
+
+interface Options {
+  /** 줌 레벨 차이가 이 값 이상일 때 버튼 표시 (기본 1) */
+  levelDeltaThreshold?: number;
+}
+
+/**
+ * 줌 레벨 변화에 따라 재검색 버튼을 보여줄지 판단하는 훅
+ * - 마지막 "검색 시점" 줌 레벨을 기억하고, 현재 줌과 비교
+ * - 버튼 클릭 시 markSearched()로 기준 갱신
+ */
+export function useZoomSearchTrigger(opts: Options = {}) {
+  const { levelDeltaThreshold = 1 } = opts;
+
+  const zoomLevel = useZoomLevel();
+  const radius = useSearchRadius();
+  const lastSearchZoomRef = useRef<number | null>(null);
+  const [visibleByZoom, setVisibleByZoom] = useState(false);
+
+  // 최초 기준값 세팅
+  useEffect(() => {
+    if (lastSearchZoomRef.current === null && typeof zoomLevel === 'number') {
+      lastSearchZoomRef.current = zoomLevel;
+    }
+  }, [zoomLevel]);
+
+  // 현재 줌과 마지막 검색 줌 비교
+  useEffect(() => {
+    if (lastSearchZoomRef.current === null) return;
+    const diff = Math.abs(zoomLevel - lastSearchZoomRef.current);
+    setVisibleByZoom(diff >= levelDeltaThreshold);
+  }, [zoomLevel, levelDeltaThreshold]);
+
+  // 검색 수행 후 기준 갱신 (버튼 숨김)
+  const markSearched = () => {
+    lastSearchZoomRef.current = zoomLevel;
+    setVisibleByZoom(false);
+  };
+
+  return {
+    visibleByZoom,
+    currentZoomLevel: zoomLevel,
+    currentRadius: radius,
+    markSearched,
+  };
+}

--- a/src/features/kakao-map/store/types.ts
+++ b/src/features/kakao-map/store/types.ts
@@ -29,6 +29,11 @@ export interface MapStoreState {
   // 위치 관련 (LocationStore 통합)
   userLocation: Position | null;
   mapCenter: Position;
+  
+  // 줌 레벨 및 검색 반경 관리
+  zoomLevel: number;
+  searchRadius: number;
+  
   // 매장 관련 (StoreListStore + Context 통합)
   stores: Store[];
   selectedStore: Store | null;
@@ -62,6 +67,10 @@ export interface MapStoreActions {
   // 위치 관련
   getCurrentLocation: (force?: boolean) => Promise<void>;
   setMapCenter: (center: Position) => void;
+  
+  // 줌 레벨 및 검색 반경 관리
+  setZoomLevel: (level: number) => void;
+  updateSearchRadius: () => void;
 
   // 즐겨찾기 관련
   setBookmarkMode: (mode: boolean) => void;

--- a/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
+++ b/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
@@ -25,7 +25,7 @@ const MyMapUuid = ({ uuid, onStoreClick }: MyMapUuidProps) => {
   const isLoggedIn = useIsLoggedIn();
   const resultAuth = useMyMapUuidQuery(uuid, isLoggedIn);
   const resultGuest = useMyMapUuidGuestQuery(uuid, !isLoggedIn);
-  console.log(`로그인상태: ${isLoggedIn}`);
+  // console.log(`로그인상태: ${isLoggedIn}`);
 
   const data = isLoggedIn ? resultAuth.data : resultGuest.data;
   const isPending = isLoggedIn ? resultAuth.isPending : resultGuest.isPending;

--- a/src/pages/AuthSuccess.tsx
+++ b/src/pages/AuthSuccess.tsx
@@ -8,7 +8,7 @@ import { userStore } from '@/shared/store/userStore';
 
 const AuthSuccess = () => {
   useEffect(() => {
-    console.log('AuthSuccess mounted', window.location.pathname);
+    // console.log('AuthSuccess mounted', window.location.pathname);
   }, []);
 
   const navigate = useNavigate();

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -1,22 +1,23 @@
-import { useUserInfoQuery } from '@mypage/hooks/useUserInfoQuery';
 import { useEffect, useState } from 'react';
 
-import MyPageHeader from '@mypage/components/MyPageHeader';
-import MyPageUserInfo from '@mypage/components/MyPageUserInfo';
-import MyPageMembership from '@mypage/components/MyPageMembership';
-import MyPageBrand from '@mypage/components/MyPageBrand';
-// import MyPageMarker from '@mypage/components/MyPageMarker';
-import type { UserInfoData, UpdateUserRequest } from '@mypage/api/types';
 import { updateUserInfo } from '@mypage/api/mypageApi';
+// import MyPageMarker from '@mypage/components/MyPageMarker';
+import type { UpdateUserRequest, UserInfoData } from '@mypage/api/types';
+import MyPageBrand from '@mypage/components/MyPageBrand';
+import MyPageHeader from '@mypage/components/MyPageHeader';
+import MyPageMembership from '@mypage/components/MyPageMembership';
+import MyPageUserInfo from '@mypage/components/MyPageUserInfo';
+import { useUserInfoQuery } from '@mypage/hooks/useUserInfoQuery';
+
 import { MyPageSkeleton } from '@/shared/components/skeleton';
 
 const MyPage = () => {
   const { data: user, isLoading, error, refetch } = useUserInfoQuery();
-  const [localUser, setLocalUser] = useState<UserInfoData | undefined>(undefined);
+  const [localUser, setLocalUser] = useState<UserInfoData | undefined>(
+    undefined
+  );
   const [editMode, setEditMode] = useState(false);
   const [pendingChanges, setPendingChanges] = useState<UpdateUserRequest>({});
-
-
 
   useEffect(() => {
     if (user) setLocalUser(user);
@@ -33,13 +34,13 @@ const MyPage = () => {
       // 모든 변경사항을 한 번에 요청
       await updateUserInfo(pendingChanges);
       //       setLocalUser(prev => prev ? { ...prev, ...pendingChanges } : prev);
-      
+
       // 데이터를 다시 가져와서 UI 업데이트
       await refetch();
-      
+
       setPendingChanges({});
       setEditMode(false);
-      console.log('통합 수정 요청 성공:', pendingChanges);
+      // console.log('통합 수정 요청 성공:', pendingChanges);
     } catch (err) {
       alert('수정 실패');
       console.error(err);
@@ -53,21 +54,21 @@ const MyPage = () => {
     <div className="min-h-screen">
       <div className="space-y-[1.5rem] pb-[6rem]">
         <MyPageHeader user={localUser} />
-        <MyPageUserInfo 
-          user={localUser} 
+        <MyPageUserInfo
+          user={localUser}
           editMode={editMode}
           setEditMode={setEditMode}
           setPendingChanges={setPendingChanges}
           onSaveAll={handleSaveAll}
         />
-        <MyPageMembership 
-          user={localUser} 
+        <MyPageMembership
+          user={localUser}
           editMode={editMode}
           pendingChanges={pendingChanges}
           setPendingChanges={setPendingChanges}
         />
-        <MyPageBrand 
-          user={localUser} 
+        <MyPageBrand
+          user={localUser}
           editMode={editMode}
           pendingChanges={pendingChanges}
           setPendingChanges={setPendingChanges}

--- a/src/shared/msw/handlers/admin.ts
+++ b/src/shared/msw/handlers/admin.ts
@@ -1,14 +1,13 @@
 import { ADMIN_ENDPOINTS } from '@admin/api/endpoints';
 import {
-    mockAdminBrandListResponse,
-    mockBookmarkStats,
-    mockFilteringStats,
-    mockMembershipStats,
-    mockRecommendStats,
-    mockTotalStats,
+  mockAdminBrandListResponse,
+  mockBookmarkStats,
+  mockFilteringStats,
+  mockMembershipStats,
+  mockRecommendStats,
+  mockTotalStats,
 } from '@admin/api/mockData';
-
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 
 const createResponse = <T>(data: T, message: string) =>
   HttpResponse.json({
@@ -21,49 +20,50 @@ export const adminHandlers = [
   http.get(ADMIN_ENDPOINTS.TOTAL_STATS, () => {
     return createResponse(mockTotalStats, '전체 통계 조회 성공');
   }),
-  
+
   http.get(ADMIN_ENDPOINTS.BOOKMARK_STATS, () => {
     return createResponse(mockBookmarkStats, '즐겨찾기 통계 조회 성공');
   }),
-  
+
   http.get(ADMIN_ENDPOINTS.FILTERING_STATS, () => {
     return createResponse(mockFilteringStats, '필터링 통계 조회 성공');
   }),
-  
+
   http.get(ADMIN_ENDPOINTS.RECOMMEND_STATS, () => {
     return createResponse(mockRecommendStats, '추천 통계 조회 성공');
   }),
-  
+
   http.get(ADMIN_ENDPOINTS.MEMBERSHIP_STATS, () => {
     return createResponse(mockMembershipStats, '멤버십 통계 조회 성공');
   }),
-  
+
   http.get(ADMIN_ENDPOINTS.BRAND_LIST, () => {
     console.log('🔧 MSW GET 브랜드 목록 조회 요청');
     return createResponse(mockAdminBrandListResponse, '브랜드 목록 조회 성공');
   }),
-  
+
   http.post(ADMIN_ENDPOINTS.BRAND_CREATE, async ({ request }) => {
     console.log('🔧 MSW POST 브랜드 생성 요청');
     const body = await request.json();
     console.log('🔧 생성할 브랜드 데이터:', body);
-    
+
     return createResponse({ brandId: 999 }, '브랜드 생성 성공');
   }),
-  
+
   http.put('/admin/brands/:brandId', async ({ params, request }) => {
     const { brandId } = params;
     console.log('🔧 MSW PUT 브랜드 수정 요청 - brandId:', brandId);
     const body = await request.json();
     console.log('🔧 수정할 브랜드 데이터:', body);
-    
+
     return createResponse({ brandId: Number(brandId) }, '브랜드 수정 성공');
   }),
-  
+
   http.delete('/admin/brands/:brandId', ({ params }) => {
     const { brandId } = params;
-    console.log('🔧 MSW DELETE 브랜드 삭제 요청 - brandId:', brandId);
-    
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔧 MSW DELETE 브랜드 삭제 요청 - brandId:', brandId);
+    }
     return createResponse('브랜드가 삭제되었습니다.', '브랜드 삭제 성공');
   }),
 ];

--- a/src/shared/msw/handlers/map.ts
+++ b/src/shared/msw/handlers/map.ts
@@ -208,9 +208,11 @@ export const mapHandlers = [
    * GET /category/:categoryId
    */
   http.get('*/category/:categoryId', ({ params, request }) => {
-    console.log('🏷️ 카테고리 브랜드 MSW 핸들러 호출:', request.url);
+    if (import.meta.env.MODE === 'development') {
+      console.log('🏷️ 카테고리 브랜드 MSW 핸들러 호출:', request.url);
+      console.log('📂 카테고리 ID:', params.categoryId);
+    }
     const categoryId = Number(params.categoryId);
-    console.log('📂 카테고리 ID:', categoryId);
 
     // categoryId 파라미터 유효성 검증
     if (isNaN(categoryId) || categoryId <= 0) {

--- a/src/shared/msw/handlers/mymap.ts
+++ b/src/shared/msw/handlers/mymap.ts
@@ -165,7 +165,9 @@ export const mymapHandlers = [
   // My Map 지도 조회 (UUID 기반, 비회원)
   http.get(MYMAP_ENDPOINTS.MYMAP.GUEST_VIEW_MSW(), async ({ params }) => {
     const uuid = params.uuid;
-    console.log(params.uuid);
+    if (import.meta.env.MODE === 'development') {
+      console.log(params.uuid);
+    }
 
     if (!uuid) {
       return createErrorResponse('UUID가 없습니다.', 400);

--- a/src/shared/msw/handlers/mypage.ts
+++ b/src/shared/msw/handlers/mypage.ts
@@ -1,10 +1,17 @@
 import { MYPAGE_ENDPOINTS } from '@/features/mypage/api/endpoints';
-import { mockUserInfoData, mockUpdateUserResponse } from '@/features/mypage/api/mockData';
-import { http, HttpResponse } from 'msw';
+import {
+  mockUpdateUserResponse,
+  mockUserInfoData,
+} from '@/features/mypage/api/mockData';
+import {
+  mockActivityStatistics,
+  mockBookmarks,
+} from '@/features/mypage/types/mockActivity';
 import type { UpdateUserRequest } from '@mypage/api/types';
-import type { ApiResponse } from '@/shared/client/client.type';
+import { HttpResponse, http } from 'msw';
 import { delay } from 'msw';
-import { mockActivityStatistics, mockBookmarks } from '@/features/mypage/types/mockActivity';
+
+import type { ApiResponse } from '@/shared/client/client.type';
 
 const createResponse = <T>(result: T, message: string): ApiResponse<T> => ({
   statusCode: 0,
@@ -16,12 +23,17 @@ export const mypageHandlers = [
   // 개인정보 수정
   http.patch(MYPAGE_ENDPOINTS.UPDATE_USER, async ({ request }) => {
     const body = (await request.json()) as Partial<UpdateUserRequest>;
-    
-    console.log('🔧 MSW PATCH 요청 받음:', body);
-    console.log('🔧 현재 mockUserInfoData:', mockUserInfoData);
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔧 MSW PATCH 요청 받음:', body);
+      console.log('🔧 현재 mockUserInfoData:', mockUserInfoData);
+    }
 
     // 에러 케이스: 잘못된 등급
-    if (body.updatedGrade && !['VVIP', 'VIP', 'GOOD'].includes(body.updatedGrade)) {
+    if (
+      body.updatedGrade &&
+      !['VVIP', 'VIP', 'GOOD'].includes(body.updatedGrade)
+    ) {
       return new HttpResponse(
         JSON.stringify({
           statusCode: 400,
@@ -48,37 +60,53 @@ export const mypageHandlers = [
     const updatedData = { ...mockUserInfoData };
     if (body.updatedNickName) {
       updatedData.nickName = body.updatedNickName;
-      console.log('✅ 닉네임 업데이트:', body.updatedNickName);
+      if (import.meta.env.MODE === 'development') {
+        console.log('✅ 닉네임 업데이트:', body.updatedNickName);
+      }
     }
     if (body.updatedGrade) {
       updatedData.grade = body.updatedGrade;
-      console.log('✅ 등급 업데이트:', body.updatedGrade);
+      if (import.meta.env.MODE === 'development') {
+        console.log('✅ 등급 업데이트:', body.updatedGrade);
+      }
     }
     if (body.updatedBrandIdList) {
       updatedData.interestedBrandList = body.updatedBrandIdList;
-      console.log('✅ 브랜드 업데이트:', body.updatedBrandIdList);
+      if (import.meta.env.MODE === 'development') {
+        console.log('✅ 브랜드 업데이트:', body.updatedBrandIdList);
+      }
     }
     updatedData.updatedAt = new Date().toISOString();
-    
+
     // 전역 mock 데이터 업데이트
     Object.assign(mockUserInfoData, updatedData);
-    
-    console.log('🔧 업데이트 후 mockUserInfoData:', mockUserInfoData);
-    
+
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔧 업데이트 후 mockUserInfoData:', mockUserInfoData);
+    }
+
     await delay(300);
-    return HttpResponse.json(createResponse(mockUpdateUserResponse, '정상 처리 되었습니다.'));
+    return HttpResponse.json(
+      createResponse(mockUpdateUserResponse, '정상 처리 되었습니다.')
+    );
   }),
-  
+
   // 개인정보 조회
   http.get(MYPAGE_ENDPOINTS.USER_INFO, () => {
-    console.log('🔧 MSW GET 요청 - 현재 mockUserInfoData:', mockUserInfoData);
-    return HttpResponse.json(createResponse(mockUserInfoData, '정상 처리 되었습니다.'));
+    if (import.meta.env.MODE === 'development') {
+      console.log('🔧 MSW GET 요청 - 현재 mockUserInfoData:', mockUserInfoData);
+    }
+    return HttpResponse.json(
+      createResponse(mockUserInfoData, '정상 처리 되었습니다.')
+    );
   }),
 
   // --- 액티비티: 활동내역 조회 ---
   http.get(MYPAGE_ENDPOINTS.STATISTICS, async () => {
     await delay(200);
-    return HttpResponse.json(createResponse(mockActivityStatistics, '정상 처리 되었습니다.'));
+    return HttpResponse.json(
+      createResponse(mockActivityStatistics, '정상 처리 되었습니다.')
+    );
   }),
 
   // --- 액티비티: 즐겨찾기 리스트 조회 ---
@@ -97,7 +125,9 @@ export const mypageHandlers = [
   http.delete(MYPAGE_ENDPOINTS.BOOKMARK_DETAIL(), async ({ params }) => {
     const { bookmarkId } = params;
     // 실제로 mockBookmarks에서 해당 id를 삭제
-    const idx = mockBookmarks.findIndex(b => b.bookmarkId === Number(bookmarkId));
+    const idx = mockBookmarks.findIndex(
+      b => b.bookmarkId === Number(bookmarkId)
+    );
     if (idx !== -1) {
       mockBookmarks.splice(idx, 1);
     }
@@ -108,4 +138,4 @@ export const mypageHandlers = [
       data: 'BOOKMARK_DELETE_SUCCESS',
     });
   }),
-]; 
+];

--- a/src/shared/store/userStore.ts
+++ b/src/shared/store/userStore.ts
@@ -42,17 +42,23 @@ export const userStore = create<UserState>()(
           // sessionStorage에 사용자 정보가 있으면 서버에서 검증
           const storedUser = get().user;
           if (storedUser) {
-            console.log(
-              '📦 sessionStorage에서 사용자 정보 발견 - 서버 검증 시작'
-            );
+            if (import.meta.env.MODE === 'development') {
+              console.log(
+                '📦 sessionStorage에서 사용자 정보 발견 - 서버 검증 시작'
+              );
+            }
             await get().userInfo();
           } else {
             // HttpOnly 쿠키는 체크할 수 없으므로 바로 서버에 요청
-            console.log('🔍 초기 인증 상태 확인 시작');
+            if (import.meta.env.MODE === 'development') {
+              console.log('🔍 초기 인증 상태 확인 시작');
+            }
             await get().userInfo();
           }
         } catch {
-          console.log('초기 인증 상태 확인 완료 (에러 발생)');
+          if (import.meta.env.MODE === 'development') {
+            console.log('초기 인증 상태 확인 완료 (에러 발생)');
+          }
           // userInfo에서 이미 에러 처리됨
         }
       },
@@ -78,10 +84,12 @@ export const userStore = create<UserState>()(
       userInfo: async () => {
         try {
           const res = await userApi.getUserInfo();
-          console.log('📡 서버 응답:', {
-            statusCode: res.statusCode,
-            data: res.data,
-          });
+          if (import.meta.env.MODE === 'development') {
+            console.log('📡 서버 응답:', {
+              statusCode: res.statusCode,
+              data: res.data,
+            });
+          }
 
           if ((res.statusCode === 200 || res.statusCode === 0) && res.data) {
             const { userName, grade, profileImage, role } = res.data;
@@ -94,7 +102,9 @@ export const userStore = create<UserState>()(
           const err = error as AxiosError<ApiError>;
           // 401이면 clearUser(), 그 외 에러는 유지
           if (err.response?.data?.statusCode === 401) {
-            console.log('🔐 401 에러 - 인증 만료로 로그아웃 처리');
+            if (import.meta.env.MODE === 'development') {
+              console.log('🔐 401 에러 - 인증 만료로 로그아웃 처리');
+            }
             get().clearUser();
           } else {
             console.warn('⚠️ 유저 정보 조회 실패(비401): 상태 유지', err);
@@ -115,7 +125,9 @@ export const userStore = create<UserState>()(
       onRehydrateStorage: () => state => {
         if (state) {
           // 복원된 상태가 있으면 서버에서 재검증 필요
-          console.log('🔄 sessionStorage에서 사용자 상태 복원됨');
+          if (import.meta.env.MODE === 'development') {
+            console.log('🔄 sessionStorage에서 사용자 상태 복원됨');
+          }
           userStore.setState({ isAuthChecked: true });
         } else {
           // 복원할 데이터가 없으면 인증 확인 완료로 설정

--- a/src/shared/utils/gaTracker.ts
+++ b/src/shared/utils/gaTracker.ts
@@ -45,6 +45,8 @@ export const trackCustomEvent = (
 ) => {
   if (MEASUREMENT_ID) {
     ReactGA.event(eventName, parameters);
-    console.log('[GA] Custom event tracked:', eventName, parameters);
+    if (import.meta.env.MODE === 'development') {
+      console.log('[GA] Custom event tracked:', eventName, parameters);
+    }
   }
 };


### PR DESCRIPTION
<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->


1. 지도 확대 레벨에 따라 매장 검색 반경을 연동하는 기능 구현
2. 지도 확대 이벤트 리스너를 통해 사용자에게 지도 UI 레벨 표시 구현
3. 메뉴얼 버튼 연동으로 반경 정보 표시 및 지도 레벨 변경 감지하여 표시 구현
4. 카카오 지도 ref 를 직접 조작하는 (prop) 확대 축소 버튼 구현

# 현재 UI 캡처

|기능 시연|
|:--:|
|![화면 기록 2025-08-04 19 34 19](https://github.com/user-attachments/assets/e4f63bd1-9a79-4470-b48e-eb66d5bb20ef)|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
