### PR TITLE
[FEAT][UHYU-414] 추천 카드 온라인 매장일때 제휴처리스트 페이지 이동하게 구현

### DIFF
--- a/src/features/recommendation/components/RecommendedCard.tsx
+++ b/src/features/recommendation/components/RecommendedCard.tsx
@@ -1,6 +1,7 @@
 import { useMapUIContext } from '@kakao-map/context/MapUIContext';
 import { useMapStore } from '@kakao-map/store/MapStore';
 import type { Store } from '@kakao-map/types/store';
+import { PATH } from '@paths';
 import ConfirmExcludeModalContent from '@recommendation/components/ConfirmExcludeModalContent';
 import { ThumbsDown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -28,7 +29,7 @@ const RecommendedStoreCard = ({
     if (!store.addressDetail) {
       if (store.brandName) {
         const query = encodeURIComponent(store.brandName);
-        navigate(`/benefit?brand_name=${query}`);
+        navigate(`${PATH.BENEFIT}?brand_name=${query}`);
       }
       return;
     }


### PR DESCRIPTION
[![UHYU-414](https://badgen.net/badge/JIRA/UHYU-414/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-414) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-414-recommend-online-card-api)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-414-recommend-online-card-api) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
온라인 제휴처 카드 클릭시 `benefit?brand_name=지니뮤직` 이런식으로 이동하게 구현

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-414]: https://u-hyu.atlassian.net/browse/UHYU-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 주소 정보가 없는 추천 매장 카드를 클릭할 때, 브랜드명이 있으면 해당 브랜드명으로 혜택 페이지로 이동하도록 개선되었습니다.  
* **버그 수정**
  * 주소와 브랜드명이 모두 없는 경우에는 아무 동작도 하지 않도록 처리되었습니다.  
* **기존 기능 유지**
  * 주소 정보가 있는 매장 카드는 기존과 동일하게 지도 이동 및 매장 선택 기능이 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->