### PR TITLE
[FIX][UHYU-411] 네비게이션바 높이, mymap, 혜택 상세보기 스타일 수정

### DIFF
--- a/src/features/benefit/components/BrandDetailModal.tsx
+++ b/src/features/benefit/components/BrandDetailModal.tsx
@@ -10,7 +10,7 @@ const BrandDetailModal = ({ brandId }: { brandId: number }) => {
 
   const gradeStyles: Record<string, { bg: string; text: string }> = {
     GOOD: { bg: 'bg-yellow', text: 'text-brown' },
-    VIP: { bg: 'bg-blue', text: 'text-primary' },
+    VIP: { bg: 'bg-blue', text: 'text-blue-500' },
     VVIP: { bg: 'bg-purple', text: 'text-purple' },
   };
 
@@ -25,31 +25,39 @@ const BrandDetailModal = ({ brandId }: { brandId: number }) => {
   return isPending ? (
     <BrandDetailSkeleton />
   ) : isError || !brand ? (
-        <div className="text-sm text-red mt-4">에러 발생</div>
-      ) :  (
+    <div className="text-sm text-red mt-4">에러 발생</div>
+  ) : (
     <div className="flex flex-col gap-4 text-black text-caption">
       <h1 className="text-body1 font-bold">{brand.brandName}</h1>
 
       <div className="flex flex-col gap-1">
         <h3 className="font-bold">등급별 혜택</h3>
         <div className="flex flex-col gap-1">
-          {brand.benefitRes.map(benefit => {
-            const { bg, text } = getGradeStyle(benefit.grade);
-            return (
-              <div
-                key={benefit.grade}
-                className={clsx(
-                  'flex justify-between items-center px-3 py-2 rounded-md',
-                  bg
-                )}
-              >
-                <span className={clsx('font-bold shrink-0 w-10', text)}>
-                  {formatGrade(benefit.grade)}
-                </span>
-                <span>{formatNewlines(benefit.description)}</span>
-              </div>
+          {(() => {
+            const gradeOrder = ['VVIP', 'VIP', 'GOOD'];
+            const sortedBenefitRes = [...brand.benefitRes].sort(
+              (a, b) =>
+                gradeOrder.indexOf(a.grade) - gradeOrder.indexOf(b.grade)
             );
-          })}
+
+            return sortedBenefitRes.map(benefit => {
+              const { bg, text } = getGradeStyle(benefit.grade);
+              return (
+                <div
+                  key={benefit.grade}
+                  className={clsx(
+                    'flex justify-between items-center px-3 py-2 rounded-md',
+                    bg
+                  )}
+                >
+                  <span className={clsx('font-bold shrink-0 w-10', text)}>
+                    {formatGrade(benefit.grade)}
+                  </span>
+                  <span>{formatNewlines(benefit.description)}</span>
+                </div>
+              );
+            });
+          })()}
         </div>
       </div>
 

--- a/src/features/kakao-map/components/BottomSheetContainer.tsx
+++ b/src/features/kakao-map/components/BottomSheetContainer.tsx
@@ -24,6 +24,7 @@ import {
 import StoreListContent from './layout/StoreListContent';
 import BrandSelectContent from './layout/steps/BrandSelectContent';
 import CategorySelectContent from './layout/steps/CategorySelectContent';
+import { MdStar } from 'react-icons/md';
 
 export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
   (_, ref) => {
@@ -211,7 +212,8 @@ export const BottomSheetContainer = forwardRef<MapDragBottomSheetRef>(
                       onClick={handleMyMapClick}
                       aria-label="MyMap으로 이동"
                     >
-                      <span>My Map</span>
+                      <MdStar className="w-5 h-5"/>
+                      <span>저장</span>
                     </button>
                   </div>
                   {/* 개선된 필터 버튼 */}

--- a/src/features/kakao-map/components/layout/StoreListContent.tsx
+++ b/src/features/kakao-map/components/layout/StoreListContent.tsx
@@ -35,7 +35,7 @@ const StoreListContent: FC<StoreListContentProps> = ({
             <div className="text-gray-400">주변에 매장이 없습니다</div>
           </div>
         ) : (
-          <div className="divide-y divide-gray-100">
+          <div className="divide-y divide-gray-100 mb-7">
             {stores.map(store => (
               <div
                 key={store.storeId}

--- a/src/features/kakao-map/components/layout/steps/BrandSelectContent.tsx
+++ b/src/features/kakao-map/components/layout/steps/BrandSelectContent.tsx
@@ -75,7 +75,7 @@ const BrandSelectContent: FC<BrandSelectContentProps> = ({
    */
   const renderBrandList = () => (
     <div className="flex-1 overflow-y-auto">
-      <div className="p-6 space-y-3">
+      <div className="p-6 space-y-3 mb-7">
         {brands.map(brand => {
           const isSelected = selectedBrand === brand;
 

--- a/src/features/kakao-map/components/layout/steps/CategorySelectContent.tsx
+++ b/src/features/kakao-map/components/layout/steps/CategorySelectContent.tsx
@@ -32,7 +32,7 @@ const CategorySelectContent: FC<CategorySelectContentProps> = ({
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto">
         <div className="p-4">
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-3 mb-7">
             {categories.map((category: CategoryType) => {
               const isSelected = selectedCategory === category.key;
 

--- a/src/features/mymap/components/bottom-sheet/MyMapList.tsx
+++ b/src/features/mymap/components/bottom-sheet/MyMapList.tsx
@@ -91,7 +91,7 @@ const MyMapList: FC = () => {
 
       {/* map 리스트 */}
       {isPending ? (
-        <div className="flex flex-col gap-2 mt-4">
+        <div className="flex flex-col gap-2 mt-4 mb-7">
           {[...Array(9)].map((_, i) => (
             <SkeletonMyMapItem key={i} />
           ))}

--- a/src/features/mymap/components/bottom-sheet/MyMapList.tsx
+++ b/src/features/mymap/components/bottom-sheet/MyMapList.tsx
@@ -9,6 +9,7 @@ import {
 import { MYMAP_COLOR, type MarkerColor } from '@mymap/constants/mymapColor';
 import { useMyMapListQuery } from '@mymap/hooks';
 import { BsThreeDotsVertical } from 'react-icons/bs';
+import { FiPlusCircle } from 'react-icons/fi';
 import { MdStars } from 'react-icons/md';
 import { MdIosShare } from 'react-icons/md';
 import { PiTrashBold } from 'react-icons/pi';
@@ -98,8 +99,24 @@ const MyMapList: FC = () => {
       ) : isError ? (
         <div className="text-sm text-red-500 mt-4">에러 발생</div>
       ) : !data || data.length === 0 ? (
-        <div className="flex text-sm text-gray-400 mt-4">
-          새 지도를 만들어주세요
+        <div className="flex  flex-col text-center items-center justify-center">
+          <img
+            src="/images/empty/empty-state.png"
+            alt="생성된 지도가 없습니다."
+            className="w-40 object-contain"
+          />
+          <div className="space-y-2">
+            <h3 className="text-body1 font-semibold text-gray-700">
+              생성된 지도가 없습니다.
+            </h3>
+
+            <p className="flex text-caption text-gray-500 leading-relaxed">
+              <span className="flex text-primary font-bold items-center mr-1">
+                <FiPlusCircle className="mr-1" />새 지도 만들기
+              </span>
+              버튼을 눌러주세요
+            </p>
+          </div>
         </div>
       ) : (
         data.map(map => (

--- a/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
+++ b/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
@@ -146,7 +146,7 @@ const MyMapUuid = ({ uuid, onStoreClick }: MyMapUuidProps) => {
             <div className="flex  flex-col text-center items-center justify-center">
               <img
                 src="/images/empty/empty-state.png"
-                alt="추천 매장이 없습니다."
+                alt="저징된 매장이 없습니다."
                 className="w-40 object-contain"
               />
               <div className="space-y-2">

--- a/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
+++ b/src/features/mymap/components/bottom-sheet/MymapUuid.tsx
@@ -9,11 +9,10 @@ import { MdIosShare, MdStars } from 'react-icons/md';
 import { PiTrashBold } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 
-import { BrandCard } from '@/shared/components';
-import { BackButton } from '@/shared/components';
+import { BackButton, BrandCard } from '@/shared/components';
+import '@/shared/components';
 import { SkeletonMyMapUuidItem } from '@/shared/components/skeleton';
-import { useModalStore } from '@/shared/store';
-import { useIsLoggedIn } from '@/shared/store/userStore';
+import { useIsLoggedIn, useModalStore } from '@/shared/store';
 
 interface MyMapUuidProps {
   uuid: string;
@@ -25,8 +24,6 @@ const MyMapUuid = ({ uuid, onStoreClick }: MyMapUuidProps) => {
   const isLoggedIn = useIsLoggedIn();
   const resultAuth = useMyMapUuidQuery(uuid, isLoggedIn);
   const resultGuest = useMyMapUuidGuestQuery(uuid, !isLoggedIn);
-  // console.log(`로그인상태: ${isLoggedIn}`);
-
   const data = isLoggedIn ? resultAuth.data : resultGuest.data;
   const isPending = isLoggedIn ? resultAuth.isPending : resultGuest.isPending;
   const isError = isLoggedIn ? resultAuth.isError : resultGuest.isError;
@@ -144,6 +141,35 @@ const MyMapUuid = ({ uuid, onStoreClick }: MyMapUuidProps) => {
               </BrandCard>
             </div>
           ))}
+          {/* 매장 없을 때 */}
+          { stores.length === 0 && isMine && (
+            <div className="flex  flex-col text-center items-center justify-center">
+              <img
+                src="/images/empty/empty-state.png"
+                alt="추천 매장이 없습니다."
+                className="w-40 object-contain"
+              />
+              <div className="space-y-2">
+                <h3 className="text-body1 font-semibold text-gray-700">
+                  저장된 매장이 없습니다.
+                </h3>
+                <p className="text-caption text-gray-500 leading-relaxed">
+                  아래 순서대로 매장을 추가할 수 있어요
+                </p>
+                <p className="text-caption text-gray-500 leading-relaxed">
+                  네비게이션바에서 지도 클릭 → 매장 마커 선택 → 별 아이콘 클릭
+                </p>
+                <button
+                  className="bg-primary text-white font-bold py-2 px-4 rounded-lg"
+                  onClick={() => {
+                    navigate('/map');
+                  }}
+                >
+                  매장 추가
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/features/mymap/components/list/MymapBody.tsx
+++ b/src/features/mymap/components/list/MymapBody.tsx
@@ -9,6 +9,7 @@ import {
 import { MYMAP_COLOR, type MarkerColor } from '@mymap/constants/mymapColor';
 import { useMyMapListQuery } from '@mymap/hooks';
 import { BsThreeDotsVertical } from 'react-icons/bs';
+import { FiPlusCircle } from 'react-icons/fi';
 import { MdStars } from 'react-icons/md';
 import { MdIosShare } from 'react-icons/md';
 import { PiTrashBold } from 'react-icons/pi';
@@ -87,8 +88,24 @@ const MyMapBody: FC = () => {
       ) : isError ? (
         <div className="text-sm text-red-500 mt-4">에러 발생</div>
       ) : !data || data.length === 0 ? (
-        <div className="flex text-sm text-gray-400 mt-4">
-          새 지도를 만들어주세요
+        <div className="flex  flex-col text-center items-center justify-center">
+          <img
+            src="/images/empty/empty-state.png"
+            alt="생성된 지도가 없습니다."
+            className="w-40 object-contain"
+          />
+          <div className="space-y-2">
+            <h3 className="text-body1 font-semibold text-gray-700">
+              생성된 지도가 없습니다.
+            </h3>
+
+            <p className="flex text-caption text-gray-500 leading-relaxed">
+              <span className="flex text-primary font-bold items-center mr-1">
+                <FiPlusCircle className="mr-1" />새 지도 만들기
+              </span>
+              버튼을 눌러주세요
+            </p>
+          </div>
         </div>
       ) : (
         data.map(map => (

--- a/src/features/mymap/components/list/MymapBody.tsx
+++ b/src/features/mymap/components/list/MymapBody.tsx
@@ -80,7 +80,7 @@ const MyMapBody: FC = () => {
 
       {/* map 리스트 */}
       {isPending ? (
-        <div className="flex flex-col gap-2 mt-4">
+        <div className="flex flex-col gap-2 mt-4 mb-7">
           {[...Array(10)].map((_, i) => (
             <SkeletonMyMapItem key={i} />
           ))}

--- a/src/features/mymap/components/list/MymapHeader.tsx
+++ b/src/features/mymap/components/list/MymapHeader.tsx
@@ -2,7 +2,7 @@ export const MymapHeader = () => (
   <div className="flex flex-col gap-4">
     <p className="text-h3 font-bold text-black">My Map</p>
     <p className="text-caption text-black">
-      마이맵을 통해 나만의 제휴처 지도를 만들어보세요.
+      마이맵을 통해 나만의 제휴처 지도를 만들어 공유해보세요.
     </p>
   </div>
 );

--- a/src/shared/components/bottom_navigation/BarcodeItem.tsx
+++ b/src/shared/components/bottom_navigation/BarcodeItem.tsx
@@ -9,7 +9,7 @@ const BarcodeItem = ({
 }: NavItemProps) => {
   return (
     <div
-      className={`w-12 h-12 z-[1004] absolute bottom-4 shadow-nav flex flex-col items-center justify-center text-white font- rounded-full cursor-pointer transition-all duration-300 pointer-events-auto
+      className={`w-12 h-12 z-[1004] absolute bottom-7 shadow-nav flex flex-col items-center justify-center text-white font- rounded-full cursor-pointer transition-all duration-300 pointer-events-auto
         ${isActive ? 'bg-black' : 'bg-gray'} 
         ${disabled ? 'opacity-50 pointer-events-none' : 'hover:bg-black hover:text-white'}`}
       onClick={onClick}

--- a/src/shared/components/bottom_navigation/BottomNavigation.tsx
+++ b/src/shared/components/bottom_navigation/BottomNavigation.tsx
@@ -78,7 +78,7 @@ const BottomNavigation = () => {
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-[1002] desktop-padding">
-      <nav className="h-12 text-[0.625rem] shadow-nav flex relative justify-around bg-white gap-5 px-[1.5rem] py-[0.5rem] z-[1003]">
+      <nav className="h-15 text-[0.625rem] shadow-nav flex relative justify-around bg-white gap-5 px-[1.5rem] py-[0.5rem] z-[1003]">
         <NavLink to={PATH.MAP} className="flex gap-4">
           <NavItem
             label="지도"

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,2 +1,4 @@
 export * from '@/shared/store/modalStore';
 export * from '@/shared/store/useImageCropStore';
+export * from '@/shared/store/barcodeStore';
+export * from '@/shared/store/userStore';


### PR DESCRIPTION
[![UHYU-411](https://badgen.net/badge/JIRA/UHYU-411/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-411) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-411-QA)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-411-QA) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
1. 네비게이션바 높이 수정
2. mymap 리스트 없을 때 처리
3. 혜택 상세보기 등급 순서 고정

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|UI 제목2|UI 제목3|
|:--:|:--:|:--:|:--:|:--:|
|<img width="331" height="715" alt="스크린샷 2025-08-06 오전 2 38 58" src="https://github.com/user-attachments/assets/4c9bae65-5dd7-4bcc-90cb-1414229cacec" />|<img width="331" height="715" alt="스크린샷 2025-08-06 오전 2 45 58" src="https://github.com/user-attachments/assets/cdd44141-ceb2-486b-9097-8ee3320845eb" />|<img width="331" height="715" alt="스크린샷 2025-08-06 오전 2 46 08" src="https://github.com/user-attachments/assets/9d8ffe56-055c-41b1-a353-aee5a4910e73" />|<img width="331" height="715" alt="스크린샷 2025-08-06 오전 3 32 57" src="https://github.com/user-attachments/assets/f08517e8-d59a-4afe-8378-e1bd99340157" />|<img width="331" height="715" alt="스크린샷 2025-08-06 오전 3 33 14" src="https://github.com/user-attachments/assets/3ef08a7b-1bd2-4000-9390-a0ef8529c072" />|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-411]: https://u-hyu.atlassian.net/browse/UHYU-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 공유 가능한 마이맵 안내 문구 추가.
  * 브랜드 혜택 등급(VVIP, VIP, GOOD) 정렬 기능 추가.

* **UI/스타일 개선**
  * 마이맵, 브랜드, 카테고리, 매장 리스트 등 여러 컴포넌트에 하단 여백(margin) 추가로 레이아웃 개선.
  * 마이맵 및 매장 리스트의 비어있는 상태에 일러스트와 안내 메시지, 아이콘 추가로 시각적 안내 강화.
  * "저장" 버튼에 별 아이콘 추가.
  * 바코드 아이템 위치 및 하단 네비게이션 바 높이 조정.

* **기타**
  * 공통 스토어(barcodeStore, userStore) 재배포로 외부 접근성 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->