### PR TITLE
[FIX][UHYU-419] 관리자 페이지 수정 메소드 변경 및 마이페이지 반응형, 토글 버튼 skicky 효과 개선

### DIFF
--- a/src/features/admin/api/adminApi.ts
+++ b/src/features/admin/api/adminApi.ts
@@ -86,7 +86,7 @@ export const adminApi = {
   },
 
   updateAdminBrand: async (brandId: number, brandData: AdminBrandUpdateRequest): Promise<AdminBrandUpdateResponse> => {
-    const res = await client.put<ApiResponse<AdminBrandUpdateResponse>>(ADMIN_ENDPOINTS.BRAND_UPDATE(brandId), brandData);
+    const res = await client.patch<ApiResponse<AdminBrandUpdateResponse>>(ADMIN_ENDPOINTS.BRAND_UPDATE(brandId), brandData);
     
     if (!res.data.data) {
       throw new Error('Invalid API response: missing data');

--- a/src/features/admin/api/types.ts
+++ b/src/features/admin/api/types.ts
@@ -79,13 +79,13 @@ export interface AdminBrandCreateRequest {
 }
 
 export interface AdminBrandUpdateRequest {
-  brandName: string;
-  brandImg: string;
-  data: AdminBrandBenefit[];
-  categoryId: number;
-  usageLimit: string;
-  usageMethod: string;
-  storeType: 'ONLINE' | 'OFFLINE';
+  brandName?: string;
+  brandImg?: string;
+  data?: AdminBrandBenefit[];
+  categoryId?: number;
+  usageLimit?: string;
+  usageMethod?: string;
+  storeType?: 'ONLINE' | 'OFFLINE';
 }
 
 export interface AdminBrandCreateResponse {

--- a/src/features/admin/components/common/AdminToggleTabs.tsx
+++ b/src/features/admin/components/common/AdminToggleTabs.tsx
@@ -32,7 +32,7 @@ const AdminToggleTabs = ({ activeTab, setActiveTab }: Props) => {
   const [isFixed, setIsFixed] = useState(false);
 
   useEffect(() => {
-    if (!sentinelRef.current) return;
+    if (!sentinelRef.current || typeof window === 'undefined' || !('IntersectionObserver' in window)) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {

--- a/src/features/admin/components/common/AdminToggleTabs.tsx
+++ b/src/features/admin/components/common/AdminToggleTabs.tsx
@@ -1,57 +1,121 @@
+import { useEffect, useRef, useState, forwardRef } from 'react';
+import { createPortal } from 'react-dom';
+
 interface Props {
   activeTab: 'stats' | 'brands';
   setActiveTab: (tab: 'stats' | 'brands') => void;
 }
 
-const AdminToggleTabs = ({ activeTab, setActiveTab }: Props) => {
-  const tabs = ['통계', '브랜드 관리'] as const;
-
-  return (
-    <div className="sticky top-0 z-10">
-      <div className="py-[0.5rem]">
-        <div
-          className="relative flex items-center justify-between bg-gray-100 rounded-[1rem] px-[0.25rem] h-[3rem]"
-          role="tablist"
-          aria-label="통계 및 브랜드 관리 탭"
-        >
-          <div
-            className={`
-              absolute top-[0.35rem] bottom-[0.35rem] left-[0.25rem]
-              w-[calc(50%-0.37rem)]
-              rounded-[0.8rem] bg-primary
-              transition-transform duration-300 ease-in-out
-              ${activeTab === 'stats' ? 'translate-x-0' : 'translate-x-[calc(100%+0.25rem)]'}
-            `}
-          />
-
-          {tabs.map((tab, index) => {
-            const tabValue = index === 0 ? 'stats' : 'brands';
-            const isActive = activeTab === tabValue;
-            return (
-              <button
-                key={tab}
-                role="tab"
-                aria-selected={isActive}
-                tabIndex={isActive ? 0 : -1}
-                onClick={() => setActiveTab(tabValue)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    setActiveTab(tabValue);
-                  }
-                }}
-                className={`
-                  relative z-10 flex-1 rounded-[1.5rem] py-[0.625rem]
-                  text-[0.875rem] font-bold transition-colors duration-200 ease-in-out
-                  ${isActive ? 'text-white' : 'text-[var(--text-gray)]'}
-                `}
-              >
-                {tab}
-              </button>
-            );
-          })}
+const FixedToggleTabContainer = forwardRef<HTMLDivElement, { children: React.ReactNode }>(
+  ({ children }, ref) => (
+    <div 
+      ref={ref}
+      className="fixed top-4 left-4 right-4 z-40 pointer-events-none desktop-content-position animate-in fade-in-0 slide-in-from-top-2 duration-300"
+    >
+      <div className="py-0 px-0">
+        <div className="flex items-center justify-start ml-[48px] pointer-events-auto">
+          <div className="w-full max-w-[calc(100vw-80px)] lg:max-w-[435px] xl:max-w-[530px] 2xl:max-w-[630px]">
+            {children}
+          </div>
         </div>
       </div>
     </div>
+  )
+);
+
+FixedToggleTabContainer.displayName = 'FixedToggleTabContainer';
+
+const AdminToggleTabs = ({ activeTab, setActiveTab }: Props) => {
+  const tabs = ['통계', '브랜드 관리'] as const;
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isFixed, setIsFixed] = useState(false);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsFixed(!entry.isIntersecting);
+      },
+      {
+        threshold: 0,
+        rootMargin: '-60px 0px 0px 0px',
+      }
+    );
+
+    observer.observe(sentinelRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const tabContent = (
+    <div
+      className={`relative flex items-center justify-between bg-gray-100 rounded-[1rem] px-[0.25rem] transition-all duration-500 ease-out ${
+        isFixed ? 'h-[44px] shadow-md' : 'h-[3rem]'
+      }`}
+      role="tablist"
+      aria-label="통계 및 브랜드 관리 탭"
+    >
+      <div
+        className={`
+          absolute top-[0.35rem] bottom-[0.35rem] left-[0.25rem]
+          w-[calc(50%-0.37rem)]
+          rounded-[0.8rem] bg-primary
+          transition-transform duration-500 ease-out
+          ${activeTab === 'stats' ? 'translate-x-0' : 'translate-x-[calc(100%+0.25rem)]'}
+        `}
+      />
+
+      {tabs.map((tab, index) => {
+        const tabValue = index === 0 ? 'stats' : 'brands';
+        const isActive = activeTab === tabValue;
+        return (
+          <button
+            key={tab}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => setActiveTab(tabValue)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                setActiveTab(tabValue);
+              }
+            }}
+            className={`
+              relative z-10 flex-1 rounded-[1.5rem] py-[0.625rem]
+              text-[0.875rem] font-bold transition-all duration-300 ease-out
+              ${isActive ? 'text-white' : 'text-[var(--text-gray)]'}
+            `}
+          >
+            {tab}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <>
+      <div ref={sentinelRef} className="h-0 w-full" aria-hidden="true" />
+   
+      <div ref={containerRef} className={`transition-opacity duration-300 ${isFixed ? 'opacity-0' : 'opacity-100'}`}>
+        <div className="py-[0.5rem]">
+          {tabContent}
+        </div>
+      </div>
+
+      {isFixed && typeof document !== 'undefined' &&
+        createPortal(
+          <FixedToggleTabContainer>
+            {tabContent}
+          </FixedToggleTabContainer>,
+          document.body
+        )
+      }
+    </>
   );
 };
 

--- a/src/features/mypage/components/ActivityFavorite.tsx
+++ b/src/features/mypage/components/ActivityFavorite.tsx
@@ -27,6 +27,9 @@ const ActivityFavorite = ({ enabled }: Props) => {
   useEffect(() => {
     if (!hasNextPage || !enabled) return;
     const currentLoader = loaderRef.current;
+    
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return;
+    
     const observer = new window.IntersectionObserver(
       entries => {
         if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {

--- a/src/features/mypage/components/ActivityTabs.tsx
+++ b/src/features/mypage/components/ActivityTabs.tsx
@@ -33,7 +33,7 @@ const ActivityTabs = ({ activeTab, setActiveTab }: Props) => {
   const [isFixed, setIsFixed] = useState(false);
 
   useEffect(() => {
-    if (!sentinelRef.current) return;
+    if (!sentinelRef.current || typeof window === 'undefined' || !('IntersectionObserver' in window)) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {

--- a/src/features/mypage/components/ActivityTabs.tsx
+++ b/src/features/mypage/components/ActivityTabs.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState, forwardRef } from 'react';
+import { createPortal } from 'react-dom';
 import type { MyPageTab } from '@mypage/types';
 import { MYPAGE_TABS } from '@mypage/constants/tabs';
 
@@ -6,52 +8,112 @@ interface Props {
   setActiveTab: (tab: MyPageTab) => void;
 }
 
-const ActivityTabs = ({ activeTab, setActiveTab }: Props) => {
-  return (
-    <div className="sticky top-0 z-10">
-      <div className="py-[0.5rem]">
-        <div
-          className="relative flex items-center justify-between bg-gray-100 rounded-[1rem] px-[0.25rem] h-[3rem]"
-          role="tablist"
-          aria-label="활동 내역 및 즐겨찾기 탭"
-        >
-        <div
-          className={`
-            absolute top-[0.35rem] bottom-[0.35rem] left-[0.25rem]
-            w-[calc(50%-0.37rem)]
-            rounded-[0.8rem] bg-primary
-            transition-transform duration-300 ease-in-out
-            ${activeTab === MYPAGE_TABS[0] ? 'translate-x-0' : 'translate-x-[calc(100%+0.25rem)]'}
-          `}
-        />
-
-        {MYPAGE_TABS.map((tab) => {
-          const isActive = activeTab === tab;
-          return (
-            <button
-              key={tab}
-              role="tab"
-              aria-selected={isActive}
-              tabIndex={isActive ? 0 : -1}
-              onClick={() => setActiveTab(tab)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  setActiveTab(tab);
-                }
-              }}
-              className={`
-                relative z-10 flex-1 rounded-[1.5rem] py-[0.625rem]
-                text-[0.875rem] font-bold transition-colors duration-200 ease-in-out
-                ${isActive ? 'text-white' : 'text-[var(--text-gray)]'}
-              `}
-            >
-              {tab}
-            </button>
-          );
-        })}
+const FixedActivityTabContainer = forwardRef<HTMLDivElement, { children: React.ReactNode }>(
+  ({ children }, ref) => (
+    <div 
+      ref={ref}
+      className="fixed top-4 left-4 right-4 z-40 pointer-events-none desktop-content-position animate-in fade-in-0 slide-in-from-top-2 duration-300"
+    >
+      <div className="py-0 px-0">
+        <div className="flex items-center justify-start ml-[48px] pointer-events-auto">
+          <div className="w-full max-w-[calc(100vw-80px)] lg:max-w-[435px] xl:max-w-[530px] 2xl:max-w-[630px]">
+            {children}
+          </div>
         </div>
       </div>
     </div>
+  )
+);
+
+FixedActivityTabContainer.displayName = 'FixedActivityTabContainer';
+
+const ActivityTabs = ({ activeTab, setActiveTab }: Props) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isFixed, setIsFixed] = useState(false);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsFixed(!entry.isIntersecting);
+      },
+      {
+        threshold: 0,
+        rootMargin: '-60px 0px 0px 0px',
+      }
+    );
+
+    observer.observe(sentinelRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const tabContent = (
+    <div
+      className={`relative flex items-center justify-between bg-gray-100 rounded-[1rem] px-[0.25rem] transition-all duration-500 ease-out ${
+        isFixed ? 'h-[44px] shadow-md' : 'h-[3rem]'
+      }`}
+      role="tablist"
+      aria-label="활동 내역 및 즐겨찾기 탭"
+    >
+      <div
+        className={`
+          absolute top-[0.35rem] bottom-[0.35rem] left-[0.25rem]
+          w-[calc(50%-0.37rem)]
+          rounded-[0.8rem] bg-primary
+          transition-transform duration-500 ease-out
+          ${activeTab === MYPAGE_TABS[0] ? 'translate-x-0' : 'translate-x-[calc(100%+0.25rem)]'}
+        `}
+      />
+
+      {MYPAGE_TABS.map((tab) => {
+        const isActive = activeTab === tab;
+        return (
+          <button
+            key={tab}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => setActiveTab(tab)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                setActiveTab(tab);
+              }
+            }}
+            className={`
+              relative z-10 flex-1 rounded-[1.5rem] py-[0.625rem]
+              text-[0.875rem] font-bold transition-all duration-300 ease-out
+              ${isActive ? 'text-white' : 'text-[var(--text-gray)]'}
+            `}
+          >
+            {tab}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <>
+      <div ref={sentinelRef} className="h-0 w-full" aria-hidden="true" />
+      <div ref={containerRef} className={`transition-opacity duration-300 ${isFixed ? 'opacity-0' : 'opacity-100'}`}>
+        <div className="py-[0.5rem]">
+          {tabContent}
+        </div>
+      </div>
+      {isFixed && typeof document !== 'undefined' &&
+        createPortal(
+          <FixedActivityTabContainer>
+            {tabContent}
+          </FixedActivityTabContainer>,
+          document.body
+        )
+      }
+    </>
   );
 };
 

--- a/src/shared/components/filter_tabs/FilterTabs.tsx
+++ b/src/shared/components/filter_tabs/FilterTabs.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import { useDrag } from '@use-gesture/react';
 import clsx from 'clsx';
@@ -70,6 +70,25 @@ const FilterTabs: FC<FilterTabProps> = ({
     }
   );
 
+  // 마우스 휠 이벤트를 passive가 아닌 모드로 처리
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      scrollContainer.scrollLeft += e.deltaY;
+    };
+
+    // passive: false로 설정하여 preventDefault가 작동하도록 함
+    scrollContainer.addEventListener('wheel', handleWheel, { passive: false });
+
+    return () => {
+      scrollContainer.removeEventListener('wheel', handleWheel);
+    };
+  }, []);
+
   return (
     <div
       ref={scrollContainerRef}
@@ -88,12 +107,7 @@ const FilterTabs: FC<FilterTabProps> = ({
               overscrollBehavior: 'contain',
             }
       }
-      onWheel={e => {
-        // 마우스 휠로 좌우 스크롤 지원
-        e.preventDefault();
-        e.stopPropagation();
-        e.currentTarget.scrollLeft += e.deltaY;
-      }}
+
       onTouchStart={e => {
         // 터치 시작 시 페이지 스크롤 방지 준비
         e.stopPropagation();


### PR DESCRIPTION
[![UHYU-419](https://badgen.net/badge/JIRA/UHYU-419/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-419) ![Medium](https://badgen.net/badge/PR%20Size/Medium/yellow) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-419-adminpage-method)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-419-adminpage-method) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)

- 마이페이지 토글 탭 위치 이동
- 관리자 페이지 토글 탭 위치 이동
- 관리자 페이지 브랜드 수정 - 메소드 PUT → FETCH
- 관리자 페이지 반응형 UI 수정
- 필터 탭 에러 해결

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-419]: https://u-hyu.atlassian.net/browse/UHYU-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 관리자 브랜드 수정 시 변경된 필드만 전송하도록 개선.
  * 관리자 및 마이페이지 탭바에 스크롤 시 상단 고정(스티키) 탭 UI 추가.

* **버그 수정**
  * 필터 탭에서 휠 스크롤 이벤트가 보다 자연스럽게 동작하도록 이벤트 처리 방식 개선.
  * IntersectionObserver 미지원 환경에서 발생할 수 있는 오류 방지.

* **UI/UX 개선**
  * 브랜드 폼의 필드 초기값 및 이미지 처리 로직 강화, UI 반응성 및 일관성 향상.
  * 탭바 고정 시 애니메이션 및 스타일 개선으로 사용성 향상.

* **기타**
  * 브랜드 수정 API 요청 방식이 PUT에서 PATCH로 변경.
  * 브랜드 수정 요청 시 모든 필드가 선택적으로 전송 가능하도록 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->