### PR TITLE
[SETTING][UHYU-420] vercel 루트 도메인으로 리다이렉트 www -> non www

### DIFF
--- a/src/features/kakao-map/context/MapUIContext.tsx
+++ b/src/features/kakao-map/context/MapUIContext.tsx
@@ -9,7 +9,7 @@ import React, {
 import type { MapDragBottomSheetRef } from '../components/controls/MapDragBottomSheet';
 
 /**
- * 지도 관련 순수 UI 상태 인터페이스
+ * 지도 관련 순수 UI 상태 인터페이스 (단 바텀 관련 상태는 ref로만 제어)
  * 비즈니스 로직과 분리된 UI 상태만 관리
  */
 interface MapUIState {
@@ -19,8 +19,6 @@ interface MapUIState {
 
   // 바텀시트 네비게이션 상태
   currentBottomSheetStep: 'list' | 'category' | 'brand' | 'mymap';
-
-  // 바텀시트 상태 제거 - ref로만 제어
 
   // 필터 UI 상태
   selectedCategory: string;
@@ -51,8 +49,6 @@ type MapUIAction =
       type: 'SET_BOTTOM_SHEET_STEP';
       payload: 'list' | 'category' | 'brand' | 'mymap';
     }
-  | { type: 'SET_BOTTOM_SHEET_EXPANDED'; payload: boolean }
-  | { type: 'TOGGLE_BOTTOM_SHEET' }
 
   // 필터 관련 액션
   | { type: 'SET_SELECTED_CATEGORY'; payload: string }
@@ -220,16 +216,6 @@ export const MapUIProvider: React.FC<{ children: React.ReactNode }> = ({
       },
       []
     ),
-
-    setBottomSheetExpanded: useCallback((expanded: boolean) => {
-      dispatch({ type: 'SET_BOTTOM_SHEET_EXPANDED', payload: expanded });
-    }, []),
-
-    toggleBottomSheet: useCallback(() => {
-      dispatch({ type: 'TOGGLE_BOTTOM_SHEET' });
-    }, []),
-
-    // 바텀시트 통합 제어 액션 제거 - ref로만 제어
 
     // 필터 관련 액션
     setSelectedCategory: useCallback((category: string) => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,12 @@
 {
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.u-hyu.site" }],
+      "destination": "https://u-hyu.site/:path*",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/assets/(.*)", "destination": "/assets/$1" },


### PR DESCRIPTION
[![UHYU-420](https://badgen.net/badge/JIRA/UHYU-420/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-420) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=feature/UHYU-420-vercel-non-www)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:feature/UHYU-420-vercel-non-www) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

1. 현재 https://www.u-hyu.site 도메인 접속 시 항상 https://u-hyu.site 로 리다이렉트 되도록 vercel 설정

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-420]: https://u-hyu.atlassian.net/browse/UHYU-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * www.u-hyu.site로 접속 시 u-hyu.site로 자동 리디렉션되도록 설정이 추가되었습니다.

* **Refactor**
  * 지도 화면에서 바텀시트 확장/축소 상태 관리를 내부 상태에서 제거하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->