### PR TITLE
[FIX] 바코드 이미지 없고 모달 켰을때 토스트 에러처리

### DIFF
--- a/src/shared/client/axiosClient.ts
+++ b/src/shared/client/axiosClient.ts
@@ -38,7 +38,9 @@ const responseInterceptor = (instance: AxiosInstance) => {
 
       // ✅ 2. 서버에서 내려준 에러 응답 처리
       if (res?.data?.statusCode && res?.data?.message) {
-        toast.error(res.data.message);
+        if (!error.config?.meta?.suppressErrorToast) {
+          toast.error(res.data.message);
+        }
         return Promise.reject({
           statusCode: res.data.statusCode,
           message: res.data.message,

--- a/src/shared/client/axiosClient.ts
+++ b/src/shared/client/axiosClient.ts
@@ -38,7 +38,7 @@ const responseInterceptor = (instance: AxiosInstance) => {
 
       // ✅ 2. 서버에서 내려준 에러 응답 처리
       if (res?.data?.statusCode && res?.data?.message) {
-        if (!error.config?.meta?.suppressErrorToast) {
+        if (res.data.statusCode !== 4103) {
           toast.error(res.data.message);
         }
         return Promise.reject({


### PR DESCRIPTION
[![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/barcode-image-error-toast)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/barcode-image-error-toast) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- PR 제목 [컨벤션][지라이슈키] 제목
예시) [FEAT][UHYU-1] 사용자 로그인 기능 구현 -->

# 주요 작업 내용 (전체 요약)
<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 서버 응답에서 `statusCode`가 4103인 경우, 더 이상 토스트 에러 알림이 표시되지 않습니다.  
  * 해당 오류는 여전히 내부적으로 처리되며, 사용자에게는 알림이 노출되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->