### PR TITLE
[FIX][UHYU-426] 브랜드 이름 개행 및 반응형 크기 조절, 토글 탭 크기 조절

### DIFF
--- a/src/features/admin/components/common/AdminToggleTabs.tsx
+++ b/src/features/admin/components/common/AdminToggleTabs.tsx
@@ -54,7 +54,7 @@ const AdminToggleTabs = ({ activeTab, setActiveTab }: Props) => {
   const tabContent = (
     <div
       className={`relative flex items-center justify-between bg-gray-100 rounded-[1rem] px-[0.25rem] transition-all duration-500 ease-out ${
-        isFixed ? 'h-[44px] shadow-md' : 'h-[3rem]'
+        isFixed ? 'h-[38px] shadow-md' : 'h-[3rem]'
       }`}
       role="tablist"
       aria-label="통계 및 브랜드 관리 탭"

--- a/src/features/mypage/components/ActivityBrands.tsx
+++ b/src/features/mypage/components/ActivityBrands.tsx
@@ -64,7 +64,7 @@ const ActivityBrands = () => {
            <div className="relative w-full h-48 sm:h-64 md:h-80 overflow-hidden">
              <div className="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-800 to-gray-700 rounded-t-3xl shadow-2xl"></div>
              
-             <div className="relative h-full flex items-end justify-center gap-1 sm:gap-2 md:gap-4 lg:gap-6 xl:gap-8 px-2 sm:px-4 md:px-6 lg:px-8 pb-2 sm:pb-4 md:pb-6 lg:pb-8">
+             <div className="relative h-full flex items-end justify-center gap-1 sm:gap-2 md:gap-4 lg:gap-6 xl:gap-8 px-2 sm:px-4 md:px-6 lg:px-8">
            
                {data.bestBrandList[2] && (
                  <div className="relative flex flex-col items-center flex-shrink-0">
@@ -79,9 +79,15 @@ const ActivityBrands = () => {
                      />
                    </div>
                    
-                   <p className="text-xs sm:text-sm md:text-base lg:text-lg xl:text-xl font-bold text-white whitespace-nowrap mb-1 sm:mb-2 md:mb-3 lg:mb-4 xl:mb-4 bg-black/30 px-1 sm:px-2 md:px-3 lg:px-4 xl:px-4 py-0.5 sm:py-1 md:py-1 lg:py-1.5 xl:py-1.5 rounded-full backdrop-blur-sm">
-                     {data.bestBrandList[2].bestBrandName}
-                   </p>
+                                       <p 
+                      className="font-bold text-white text-center mb-1 sm:mb-2 md:mb-3 lg:mb-4 xl:mb-4 max-w-[70px] sm:max-w-[85px] md:max-w-[100px] lg:max-w-[115px] xl:max-w-[130px] break-words"
+                      style={{
+                        fontSize: `clamp(${Math.max(6, 14 - data.bestBrandList[2].bestBrandName.length * 0.6)}px, ${Math.max(8, 16 - data.bestBrandList[2].bestBrandName.length * 0.5)}px, ${Math.max(10, 18 - data.bestBrandList[2].bestBrandName.length * 0.4)}px)`,
+                        lineHeight: '1.2'
+                      }}
+                    >
+                      {data.bestBrandList[2].bestBrandName}
+                    </p>
                    
                    <div className="absolute -top-0 -right-0 sm:-top-2.5 sm:-right-2.5 md:-top-3 md:-right-3 lg:-top-3 lg:-right-3 xl:-top-4 xl:-right-4 w-3 h-3 sm:w-4 sm:h-4 md:w-5 md:h-5 lg:w-6 lg:h-6 xl:w-7 xl:h-7 bg-amber-500 rounded-full flex items-center justify-center shadow-lg border border-white">
                      <span className="text-[8px] sm:text-[8px] md:text-xs lg:text-sm xl:text-sm font-bold text-white">3</span>
@@ -106,9 +112,15 @@ const ActivityBrands = () => {
                    </div>
                    
                   
-                   <p className="text-xs sm:text-sm md:text-base lg:text-lg xl:text-xl font-bold text-white whitespace-nowrap mb-1 sm:mb-2 md:mb-3 lg:mb-4 xl:mb-4 bg-black/30 px-1 sm:px-2 md:px-3 lg:px-4 xl:px-4 py-0.5 sm:py-1 md:py-1 lg:py-1.5 xl:py-1.5 rounded-full backdrop-blur-sm">
-                     {data.bestBrandList[0].bestBrandName}
-                   </p>
+                                       <p 
+                      className="font-bold text-white text-center mb-1 sm:mb-2 md:mb-3 lg:mb-4 xl:mb-4 max-w-[70px] sm:max-w-[85px] md:max-w-[100px] lg:max-w-[115px] xl:max-w-[130px] break-words"
+                      style={{
+                        fontSize: `clamp(${Math.max(6, 14 - data.bestBrandList[0].bestBrandName.length * 0.6)}px, ${Math.max(8, 16 - data.bestBrandList[0].bestBrandName.length * 0.5)}px, ${Math.max(10, 18 - data.bestBrandList[0].bestBrandName.length * 0.4)}px)`,
+                        lineHeight: '1.2'
+                      }}
+                    >
+                      {data.bestBrandList[0].bestBrandName}
+                    </p>
                    
               
                    <div className="absolute -top-0 -right-[-5px] sm:-top-2.5 sm:-right-2.5 md:-top-3 md:-right-3 lg:-top-3 lg:-right-3 xl:-top-4 xl:-right-4 w-3 h-3 sm:w-4 sm:h-4 md:w-5 md:h-5 lg:w-6 lg:h-6 xl:w-7 xl:h-7 bg-yellow-400 rounded-full flex items-center justify-center shadow-lg border border-white">
@@ -133,9 +145,15 @@ const ActivityBrands = () => {
                      />
                    </div>
                    
-                   <p className="text-xs sm:text-sm md:text-base lg:text-lg xl:text-xl font-bold text-white whitespace-nowrap mb-1 sm:mb-2 md:mb-3 lg:mb-4 xl:mb-4 bg-black/30 px-1 sm:px-2 md:px-3 lg:px-4 xl:px-4 py-0.5 sm:py-1 md:py-1 lg:py-1.5 xl:py-1.5 rounded-full backdrop-blur-sm">
-                     {data.bestBrandList[1].bestBrandName}
-                   </p>
+                                       <p 
+                      className="font-bold text-white text-center mb-1 sm:mb-2 md:mb-3 lg:mb-4 xl:mb-4 max-w-[70px] sm:max-w-[85px] md:max-w-[100px] lg:max-w-[115px] xl:max-w-[130px] break-words"
+                      style={{
+                        fontSize: `clamp(${Math.max(6, 14 - data.bestBrandList[1].bestBrandName.length * 0.6)}px, ${Math.max(8, 16 - data.bestBrandList[1].bestBrandName.length * 0.5)}px, ${Math.max(10, 18 - data.bestBrandList[1].bestBrandName.length * 0.4)}px)`,
+                        lineHeight: '1.2'
+                      }}
+                    >
+                      {data.bestBrandList[1].bestBrandName}
+                    </p>
                   
                    <div className="absolute -top-0 -right-[-4px] sm:-top-2.5 sm:-right-2.5 md:-top-3 md:-right-3 lg:-top-3 lg:-right-3 xl:-top-4 xl:-right-4 w-3 h-3 sm:w-4 sm:h-4 md:w-5 md:h-5 lg:w-6 lg:h-6 xl:w-7 xl:h-7 bg-gray-300 rounded-full flex items-center justify-center shadow-lg border border-white">
                      <span className="text-[8px] sm:text-[8px] md:text-xs lg:text-sm xl:text-sm font-bold text-white">2</span>

--- a/src/features/mypage/components/ActivityTabs.tsx
+++ b/src/features/mypage/components/ActivityTabs.tsx
@@ -55,7 +55,7 @@ const ActivityTabs = ({ activeTab, setActiveTab }: Props) => {
   const tabContent = (
     <div
       className={`relative flex items-center justify-between bg-gray-100 rounded-[1rem] px-[0.25rem] transition-all duration-500 ease-out ${
-        isFixed ? 'h-[44px] shadow-md' : 'h-[3rem]'
+        isFixed ? 'h-[38px] shadow-md' : 'h-[3rem]'
       }`}
       role="tablist"
       aria-label="활동 내역 및 즐겨찾기 탭"


### PR DESCRIPTION
[![UHYU-426](https://badgen.net/badge/JIRA/UHYU-426/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-426) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-426-brand-name)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-426-brand-name) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)

마이페이지의 마커 클릭 수 컴포넌트 안에 브랜드 이름 개행 처리 및 반응형 크기 조절
마이페이지 활동내역 및 관리자 페이지 토글 탭 크기 조절

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-426]: https://u-hyu.atlassian.net/browse/UHYU-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 고정 상태의 탭 컨테이너 높이가 44픽셀에서 38픽셀로 조정되었습니다.
  * 브랜드 이름 표시가 동적으로 글자 수에 따라 크기가 조절되며, 긴 이름도 잘 보이도록 스타일이 개선되었습니다.
  * 브랜드 아이콘 및 이름 컨테이너의 하단 여백이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->