### PR TITLE
[BUG][UHYU-428] mymap 폴더 데이터

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width,initial-scale=1.0,user-scalable=no,maximum-scale=1, viewport-fit=cover"
+      content="width=device-width,initial-scale=1.0,user-scalable=no,maximum-scale=1,viewport-fit=cover"
     />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <link
@@ -90,5 +90,32 @@
       integrity="..."
       crossorigin="anonymous"
     ></script>
+    <script>
+      function fixViewport() {
+        const viewport = document.querySelector('meta[name="viewport"]');
+        if (viewport) {
+          viewport.content =
+            'width=device-width,initial-scale=1.0,user-scalable=no,maximum-scale=1,viewport-fit=cover';
+        }
+      }
+
+      // 여러 시점에서 viewport 수정
+      document.addEventListener('DOMContentLoaded', fixViewport);
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) {
+          setTimeout(fixViewport, 100);
+        }
+      });
+
+      // React 앱 로드 후에도 실행 (추가)
+      window.addEventListener('load', () => {
+        setTimeout(fixViewport, 200);
+      });
+
+      // 포커스 이벤트 추가 (웹앱 재진입 시)
+      window.addEventListener('focus', () => {
+        setTimeout(fixViewport, 100);
+      });
+    </script>
   </body>
 </html>

--- a/src/features/mymap/components/modal/MymapDeleteModal.tsx
+++ b/src/features/mymap/components/modal/MymapDeleteModal.tsx
@@ -1,14 +1,8 @@
 import { useDeleteMyMapMutation } from '@mymap/hooks';
 import { toast } from 'sonner';
 
-
-
 import { BaseModal, PrimaryButton } from '@/shared/components';
 import { useModalStore } from '@/shared/store';
-
-
-
-
 
 interface MymapDeleteModalProps {
   mapId: number;

--- a/src/features/mymap/hooks/useAddMyMapMutation.ts
+++ b/src/features/mymap/hooks/useAddMyMapMutation.ts
@@ -10,7 +10,7 @@ export const useAddMyMapMutation = () => {
   return useMutation({
     mutationFn: addMyMap,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['mymaplist'] });
+      queryClient.refetchQueries({ queryKey: ['mymaplist'] });
     },
   });
 };

--- a/src/features/mymap/hooks/useDeleteMyMapMutation.ts
+++ b/src/features/mymap/hooks/useDeleteMyMapMutation.ts
@@ -9,7 +9,7 @@ export const useDeleteMyMapMutation = () => {
   return useMutation({
     mutationFn: deleteMyMap,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['mymaplist'] });
+      queryClient.refetchQueries({ queryKey: ['mymaplist'] });
     },
     onError: error => {
       console.error('지도 삭제 중 오류가 발생했습니다:', error);

--- a/src/features/mymap/hooks/useMyMapListQuery.ts
+++ b/src/features/mymap/hooks/useMyMapListQuery.ts
@@ -10,5 +10,7 @@ export const useMyMapListQuery = () => {
   return useQuery<MyMapListRes[]>({
     queryKey: ['mymaplist'],
     queryFn: getMyMapList,
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 };

--- a/src/features/mymap/hooks/useUpdateMyMapMutation.ts
+++ b/src/features/mymap/hooks/useUpdateMyMapMutation.ts
@@ -10,7 +10,7 @@ export const useUpdateMyMapMutation = () => {
   return useMutation({
     mutationFn: updateMyMap,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['mymaplist'] });
+      queryClient.refetchQueries({ queryKey: ['mymaplist'] });
     },
   });
 };


### PR DESCRIPTION
# 주요 작업 내용 (전체 요약)
1.문제
iOS Safari에서 웹앱 첫 실행 시에는 정상 작동
앱 종료 후 재진입 시 viewport 설정이 초기화되어 레이아웃 문제 발생
기존 meta 태그만으로는 앱 재시작 시 viewport가 제대로 적용되지 않음

해결 방법
JavaScript를 통한 동적 viewport 재설정 로직 추가:

- 다중 이벤트 리스너 추가
DOMContentLoaded: 페이지 초기 로드 시
visibilitychange: 앱이 백그라운드에서 포그라운드로 전환 시
load: React 앱 완전 로드 후
focus: 웹앱 재진입 시

- fixViewport 함수
viewport meta 태그를 동적으로 찾아서 content 속성 재설정
지연 실행으로 렌더링 타이밍 이슈 해결

2.문제
MyMap 폴더 생성, 수정, 삭제 후 UI에서 실시간으로 반영되지 않던 문제

해결방법
- `useAddMyMapMutation`, `useDeleteMyMapMutation`, `useUpdateMyMapMutation`에서
  `invalidateQueries` → `refetchQueries`로 변경하여 강제 갱신
- `useMyMapListQuery`에 다음 옵션 추가
  - `staleTime: 0` → 항상 새로운 데이터를 요청하도록 설정
  - `refetchOnMount: 'always'` → 컴포넌트 마운트 시에도 항상 최신 상태 유지

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-
