### PR TITLE
[BUG][UHYU-431] 매장 추가 모달 refetch 및 줄바꿈 처리 추가

### DIFF
--- a/src/features/benefit/utils/formatUsageText.ts
+++ b/src/features/benefit/utils/formatUsageText.ts
@@ -1,9 +1,5 @@
 import he from 'he';
 
-
-
-
-
 /**
  * usageMethod나 usageLimit 등의 긴 설명 텍스트를 보기 좋게 줄바꿈 처리하고 디코딩하는 유틸
  */

--- a/src/features/benefit/utils/formatUsageText.ts
+++ b/src/features/benefit/utils/formatUsageText.ts
@@ -1,5 +1,9 @@
 import he from 'he';
 
+
+
+
+
 /**
  * usageMethod나 usageLimit 등의 긴 설명 텍스트를 보기 좋게 줄바꿈 처리하고 디코딩하는 유틸
  */
@@ -14,10 +18,12 @@ export const formatUsageText = (text: string | null): string => {
 
   // 3. 보기 좋게 줄바꿈 처리 (기호 앞에 줄바꿈 추가)
   decoded = decoded
+    .replace(/\s*●\s*/g, '\n● ')
     .replace(/\s*■\s*/g, '\n■ ')
     .replace(/\s*▶\s*/g, '\n▶ ')
     .replace(/\s*\*\s*/g, '\n* ')
-    .replace(/(?<!\d)\s*-\s*/g, '\n- ');
+    .replace(/(?<!\d)\s*-\s*/g, '\n- ')
+    .replace(/(^|\s)([1-5])\.\s*/g, '\n$2. ');
 
   // 4. 여러 연속 공백 정리
   decoded = decoded.replace(/\s{2,}/g, ' ');

--- a/src/features/mymap/components/modal/AddStoreModal.tsx
+++ b/src/features/mymap/components/modal/AddStoreModal.tsx
@@ -23,10 +23,15 @@ interface AddStoreProps {
 }
 
 const AddStoreModal: FC<AddStoreProps> = ({ storeId }) => {
-  const { data, isLoading, isError } = useStoreBookmarkStatusQuery(storeId);
+  const { data, refetch, isLoading, isError } =
+    useStoreBookmarkStatusQuery(storeId);
   const toggleMutation = useToggleMyMapStoreMutation();
   const toggleFavoriteMutation = useToggleFavoriteMutation();
   const closeModal = useModalStore(state => state.closeModal);
+
+  useEffect(() => {
+    refetch();
+  }, []);
 
   // my map 초기 체크 상태 저장용
   const [initialCheckedMap, setInitialCheckedMap] = useState<


### PR DESCRIPTION
[![UHYU-431](https://badgen.net/badge/JIRA/UHYU-431/blue?icon=jira)](https://u-hyu.atlassian.net/browse/UHYU-431) [![](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml/badge.svg?branch=fix/UHYU-431-mymap-bug)](https://github.com/u-hyu/u-hyu/actions/workflows/ci.yml?query=branch:fix/UHYU-431-mymap-bug) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=U-Final&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# 주요 작업 내용 (전체 요약)
- `AddStoreModal`이 열릴 때 `useStoreBookmarkStatusQuery`를 강제로 `refetch()` 하도록 수정하여,
  즐겨찾기 또는 MyMap 저장 상태 변경 후 모달을 다시 열었을 때 최신 상태가 반영되도록 개선했습니다.

- `formatUsageText` 유틸 함수에 다음과 같은 줄바꿈 처리 로직을 추가했습니다:
  - `.replace(/(^|\s)([1-5])\.\s*/g, '\n$2. ')`: 1~5. 형식의 숫자 앞에 줄바꿈 추가
  - `.replace(/\s*●\s*/g, '\n● ')`: ● 기호 앞에 줄바꿈 추가

# 현재 UI 캡처

|UI 제목1|UI 제목2|UI 제목3|
|:--:|:--:|:--:|
|이미지링크|이미지링크|이미지링크|

## 체크리스트

- [ ] 테스트 코드를 작성했나요?
- [ ] 코드와 문서의 포맷팅 및 린트를 위해 `npm run fix`를 실행했나요?
- [ ] 커버되지 않은 라인이 없는지 확인하기 위해 `npm run test:coverage`를 실행했나요?
- [ ] JSDoc을 작성했나요?
-

[UHYU-431]: https://u-hyu.atlassian.net/browse/UHYU-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용 안내 텍스트에서 목록 기호(●, 번호 등) 앞에 줄바꿈이 추가되어 가독성이 향상되었습니다.
  * 매장 즐겨찾기 추가 모달을 열 때, 즐겨찾기 상태가 항상 최신 정보로 자동 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->